### PR TITLE
Update buffer_feeder.py

### DIFF
--- a/klipper_extras/buffer_feeder.py
+++ b/klipper_extras/buffer_feeder.py
@@ -552,6 +552,16 @@ class BufferFeeder:
             logging.exception("buffer_feeder: shutdown stepper disable failed")
 
     def _on_idle_printing(self, *args):
+        # Klipper fires idle_timeout:printing during MCU init even without
+        # an active print (print_stats state = 'standby'). Guard against
+        # this boot artifact so _print_running is only armed for real prints.
+        try:
+            ps = self.printer.lookup_object('print_stats', None)
+            if ps is not None:
+                if ps.get_status(self.reactor.monotonic()).get('state', '') == 'standby':
+                    return
+        except Exception:
+            pass
         self._print_running = True
         # RESUME / print-start: bang-bang resumes.
         self._bang_bang_suspended = False


### PR DESCRIPTION
Klipper feuert idle_timeout:printing während der MCU-Initialisierung auch dann, wenn kein Druck aktiv ist. Dadurch wurde _print_running bei jedem Boot auf True gesetzt, was eine falsche "Print paused — bang-bang suspended"-Meldung auslöste und BUFFER_AUTO_ON mit einem Fehler zum Absturz brachte.

Fix: _on_idle_printing prüft jetzt print_stats.state bevor _print_running gesetzt wird. Ist der State standby (Boot-Artefakt), kehrt der Handler sofort zurück. Nur ein echter Druckstart (state == 'printing') setzt das Flag.