### PR TITLE
Update buffer_feeder.py

### DIFF
--- a/klipper_extras/buffer_feeder.py
+++ b/klipper_extras/buffer_feeder.py
@@ -886,7 +886,7 @@ class BufferFeeder:
                 # 1st click — start.
                 self._measure_feeding = True
                 self._measure_load_distance = 0.0
-                self._start_continuous_motion(+1, self.manual_speed, None)
+                self._submit_move(self.max_feed_distance, self.manual_speed)
                 self._set_state(STATE_MANUAL_FEED)
                 self._respond("MEASURE_LOAD: feeder running — click again to stop")
             return


### PR DESCRIPTION
MEASURE_LOAD_START nutzte beim ersten Tastendruck _start_continuous_motion, das Bewegung in 10-mm-Chunks schickt. Zwischen zwei Chunks entsteht durch die lead_time (0,3 s) eine kurze Pause — der Feeder schien für den Operator kurz zu stoppen. Ein zweiter Tastendruck beim vermeintlichen Stopp beendete die Messung verfrüht mit nur einem akkumulierten Chunk (~10 mm statt der tatsächlichen Buffer-zu-Toolhead-Distanz).

Fix: Statt _start_continuous_motion wird _submit_move(max_feed_distance, manual_speed) aufgerufen. Dieser Mechanismus reiht den nächsten Chunk bereits ein bevor der laufende endet — die Bewegung läuft lückenlos durch. Der zweite Tastendruck stoppt via _halt_motion() sauber.