### PR TITLE
Update buffer_feeder.py

### DIFF
--- a/klipper_extras/buffer_feeder.py
+++ b/klipper_extras/buffer_feeder.py
@@ -527,6 +527,10 @@ class BufferFeeder:
             % (self.hall_empty, self.hall_full,
                self.hall_overflow, self.entrance_detected),
             force_display=True)
+        # If no filament is present at boot, mark the entrance as having
+        # been empty so the first real insert triggers auto-grip immediately.
+        if not self.entrance_detected:
+            self._entrance_was_empty = True
         # Drop into normal operation. If HALL1 is currently active,
         # main_tick will immediately transition to OVERFLOW.
         self._set_state(STATE_IDLE)


### PR DESCRIPTION
_entrance_was_empty wurde mit False initialisiert. Das Flag wird normalerweise auf True gesetzt wenn Filament am Eingang entfernt wird, damit der nächste Insert den Auto-Grip auslöst. War beim Boot kein Filament vorhanden, wurde keine "leer"-Flanke beobachtet — das Flag blieb False und der erste Insert wurde ignoriert. Erst nach einem Rausziehen-und-Einlegen-Zyklus funktionierte der Auto-Grip.

Fix: Am Ende der Startup-Grace-Period wird _entrance_was_empty auf True gesetzt wenn kein Filament am Eingang erkannt ist. Damit ist der erste echte Insert direkt gripfähig. Der bestehende Schutz (Filament bereits beim Boot vorhanden → Flag bleibt False → kein ungewollter Grip) bleibt unberührt.