### PR TITLE
sync_to_extruder: Feeder-Startposition auf extruder.last_position setzen

### DIFF
--- a/klipper_extras/buffer_feeder.py
+++ b/klipper_extras/buffer_feeder.py
@@ -499,7 +499,17 @@ class SyncCoordinator:
         toolhead = owner.printer.lookup_object('toolhead')
         try:
             toolhead.flush_step_generation()
-            owner.stepper.set_position((0., 0., 0.))
+            # P7-47: Feeder-Startposition auf die tatsächliche commanded_pos
+            # des Extruder-Steppers setzen, nicht auf (0,0,0). Nach LOAD steht
+            # der Extruder-Stepper intern bei z.B. 180mm; set_position((0,0,0))
+            # würde den Feeder auf 0 setzen während itersolve Schritte ab 180mm
+            # berechnet → alle Schritte landen bei t=0 → {i=0,c=N} Invalid
+            # sequence. extruder.last_position ist die physikalische
+            # commanded_pos des Extruder-Steppers (unabhängig von G92-Offsets)
+            # — selbes Pattern wie Klipper's ExtruderStepper.sync_to_extruder
+            # (extruder.py:968ff) und _read_extruder_position() in dieser Datei.
+            _ext_pos = extruder.last_position
+            owner.stepper.set_position((_ext_pos, 0., 0.))
             owner.stepper.set_trapq(extruder.get_trapq())
             self.motion_queuing.check_step_generation_scan_windows()
         except Exception:


### PR DESCRIPTION
## Problem

`sync_to_extruder()` rief `owner.stepper.set_position((0., 0., 0.))` auf, bevor der Feeder-Stepper in den Extruder-Trapq eingehängt wurde. Nach einem LOAD steht der Extruder-Stepper intern bei z. B. 180 mm (`commanded_pos` im itersolve-Cursor). Der Feeder-Stepper wurde auf 0 gesetzt, obwohl der Extruder-Trapq ab 180 mm rechnet. Dadurch kollabieren alle generierten Schritte auf denselben Zeitstempel → MCU-Shutdown mit `stepcompress o=0 i=0 c=N a=0: Invalid sequence`.

Das Ergebnis: Ein UNLOAD nach einem LOAD war grundsätzlich nicht möglich – erst ein Klipper-Neustart stellte den Normalbetrieb wieder her.

## Fix

`extruder.last_position` liefert die physikalische `commanded_pos` des Extruder-Steppers, unabhängig von G92-Offsets. Der Feeder-Stepper wird jetzt mit genau dieser Position initialisiert, bevor der Trapq-Swap stattfindet.

Das ist dasselbe Pattern, das Klipper intern in `ExtruderStepper.sync_to_extruder()` (`kinematics/extruder.py`, Zeile 968 ff.) und in `_read_extruder_position()` dieser Datei verwendet.

Das Fix wurde auf echter Hardware verifiziert: UNLOAD nach LOAD funktioniert danach zuverlässig ohne MCU-Shutdown.

## Begleitende Änderungen

Keine.

## Abhängigkeiten

Setzt P7-46 voraus.