### PR TITLE
fix(buffer_feeder): Stabilitätsfixes für P7-52 (flush-callback bang-bang)

### DIFF
--- a/klipper_extras/buffer_feeder.py
+++ b/klipper_extras/buffer_feeder.py
@@ -807,6 +807,10 @@ class BufferFeeder:
         # HALT / OVERFLOW can take effect within one chunk instead
         # of waiting out the full nominal move duration.
         self.max_move_chunk_mm  = config.getfloat('max_move_chunk_mm',  50.0,  above=0.)
+        # Flush-Callback-Pfad benutzt einen eigenen, kleineren Chunk damit
+        # der Feeder den HALL1-Overflow-Bereich nicht ueberschiesst.
+        # Default 15.0mm = HALL3->HALL2-Pufferweg am Mellow LLL Plus.
+        self.flush_callback_chunk_mm = config.getfloat('flush_callback_chunk_mm', 15.0, above=0.)
 
         # ----- Config: jam detection -----
         self.jam_detection_enabled = config.getboolean('jam_detection_enabled', True)
@@ -983,6 +987,11 @@ class BufferFeeder:
         self._continuous_feed_direction = 0 # +1 or -1
         self._continuous_feed_speed = 0.0
         self._pending_disable = False       # deferred stepper disable (while move in flight)
+        # P7-54: After OVERFLOW → IDLE → AUTO the stepcompress cursor
+        # is out of sync. _main_tick handles the safe resync (forced_t0=None
+        # path → flush_step_generation allowed). _on_mcu_flush skips while
+        # this flag is set to prevent submitting on an unsynced cursor.
+        self._needs_overflow_prime = False
         self._feed_deadline_time = None     # max feed deadline (reactor time)
         self._measure_load_active = False
         self._measure_load_distance = 0.0
@@ -1615,6 +1624,11 @@ class BufferFeeder:
         if self._state != STATE_OVERFLOW:
             return
         self._respond("HALL1 cleared — overflow lockout released")
+        # P7-54: Mark cursor resync pending. _main_tick will submit a
+        # 0.05mm anchor with forced_t0=None (safe reactor context) so the
+        # stepcompress cursor is synchronised before the first fill-move.
+        # _on_mcu_flush skips while this flag is set (see below).
+        self._needs_overflow_prime = True
         # Go to IDLE (the _set_state hook calls _halt_motion + stepper-disable).
         self._set_state(STATE_IDLE)
         self._fault_overflow = False
@@ -1769,6 +1783,14 @@ class BufferFeeder:
             # auf SYNC_TO_EXTRUDER umgestellt — UNLOAD_PHASE_1 wird
             # nicht mehr betreten.)
             if self._state == STATE_AUTO:
+                # P7-54: Post-OVERFLOW cursor resync. After OVERFLOW →
+                # IDLE → AUTO the stepcompress cursor is stale. Submit
+                # a tiny anchor with forced_t0=None so flush_step_
+                # generation (allowed here, reactor context) syncs the
+                # cursor before the first flush-callback fill-move.
+                if self._needs_overflow_prime:
+                    self._needs_overflow_prime = False
+                    self._submit_move(0.05, self.feed_speed, forced_t0=None)
                 self._bang_bang_tick(eventtime)
 
             self._tick_runout_follow(eventtime)
@@ -1999,6 +2021,12 @@ class BufferFeeder:
             # bang only acts in AUTO. LOAD/UNLOAD-driven SYNC paths
             # are handled by their own macros, not by us.
             return
+        if self._needs_overflow_prime:
+            # P7-54: Post-OVERFLOW prime is pending. _main_tick will
+            # submit a safe anchor-move (forced_t0=None, reactor context)
+            # to resync the stepcompress cursor first. Submitting here
+            # on the unsynchronised cursor would cause Invalid sequence.
+            return
         if self._stepper_synced_to is not None:
             # An explicit BUFFER_SYNC_TO_EXTRUDER (macro path) is in
             # effect. Stay out of the way — submitting our own move
@@ -2021,7 +2049,7 @@ class BufferFeeder:
             # safe anchor — Klipper just told us the cursor is here.
             if not self._continuous_feed:
                 anchor = step_gen_time + self.lead_time
-                self._submit_move(self.max_move_chunk_mm,
+                self._submit_move(self.flush_callback_chunk_mm,
                                    self.feed_speed,
                                    forced_t0=anchor)
                 self._continuous_feed = True
@@ -2404,20 +2432,27 @@ class BufferFeeder:
         #   has no baseline for → "Invalid sequence" shutdown.
         # mcu/mcu_now sind oben fuer den Re-Prime-Gap-Check schon
         # berechnet — wiederverwenden statt neu fetchen.
+        # _enable_stepper() above bumped _last_enable_schedule_time via
+        # _schedule_time_for_enable_toggle(). t0 must be >= that value
+        # in ALL paths so motor-enable fires before (or at) the first
+        # step. Without this floor: t0 = _last_move_end_time < enable_pt
+        # → enable AFTER steps → "Invalid sequence" MCU-Shutdown
+        # (Hardware 2026-04-29, c=22 i=0).
+        en = self._last_enable_schedule_time
         if forced_t0 is not None:
             # P7-52 flush-callback path: caller provides a step_gen_
             # time-based anchor that is race-free against Klipper's
             # MCU flush cycle. Honor _last_move_end_time as the floor
             # so streaming chunks still abut without gap.
-            t0 = max(forced_t0, self._last_move_end_time)
+            t0 = max(forced_t0, self._last_move_end_time, en)
         elif self._last_move_end_time > mcu_now + self.lead_time:
             # Streaming: previous chunk is still in the future — abut.
-            t0 = self._last_move_end_time
+            t0 = max(self._last_move_end_time, en)
         else:
             # First chunk / gap: anchor to toolhead print_time.
             toolhead = self.printer.lookup_object('toolhead')
             th_time = toolhead.get_last_move_time()
-            t0 = max(th_time + self.lead_time, self._last_move_end_time)
+            t0 = max(th_time + self.lead_time, self._last_move_end_time, en)
 
         distance = abs(signed_distance)
         direction = 1.0 if signed_distance > 0 else -1.0
@@ -3559,6 +3594,8 @@ class BufferFeeder:
             'use_python_unload':        self.use_python_unload,
             'use_fault_overlay':        self.use_fault_overlay,
             'accel':                    self.accel,
+            'max_move_chunk_mm':        self.max_move_chunk_mm,
+            'flush_callback_chunk_mm':  self.flush_callback_chunk_mm,
         }
 
 

--- a/lll.cfg
+++ b/lll.cfg
@@ -122,6 +122,8 @@ reenable_cooldown:      1.0       # s nach Manual-Op bevor AUTO wiederkommt
 reenable_cooldown_fast: 0.5       # s nach Burst
 use_python_unload:      0         # 0 = legacy macro, 1 = Python workflow
 use_fault_overlay:      0         # 0 = legacy fault-states; 1 aktiviert Overlay nur fuer LOAD_PHASE_3-Overflow (P7-35); RUNOUT/JAM/anderer OVERFLOW bleiben legacy
+use_flush_callback_bang_bang: True
+flush_callback_chunk_mm: 15.0        # Chunk-Größe für _on_mcu_flush (HALL3→HALL2 Mellow LLL Plus)
 
 # --- Initial-Fill / Sicherheit ---
 auto_load_after_follow: 0         # 1 = nach Grip automatisch LOAD_FILAMENT falls heiß


### PR DESCRIPTION
## Problem

Hardware-Crash 2026-04-29 — `stepcompress o=0 i=0 c=22 a=0: Invalid sequence`
nach OVERFLOW-Recovery beim Betrieb mit `use_flush_callback_bang_bang=True` (P7-52).

## Fix

Drei zusammengehörende Fixes die für stabilen P7-52-Betrieb notwendig sind:

**1. t0-Enable-Floor**
`_enable_stepper()` wird in `_submit_single_trapezoid` VOR der t0-Berechnung aufgerufen. `_schedule_time_for_enable_toggle()` bumpt `_last_enable_schedule_time` dabei in die Zukunft. Alle drei t0-Pfade (forced/streaming/anchor) ignorierten diesen Wert — `t0` blieb bei `_last_move_end_time`. Resultat: `enable_pt > t0`, Motor-Enable feuert NACH dem ersten Step → Invalid sequence MCU-Shutdown.
Fix: `en = self._last_enable_schedule_time` nach `_enable_stepper()` lesen, als Floor in alle drei `max()`-Ausdrücke einbauen.

**2. Post-OVERFLOW-Prime (`_needs_overflow_prime`)**
Nach OVERFLOW → IDLE → AUTO ist der Stepcompress-Cursor nicht synchron. Im Flush-Callback-Modus läuft `_on_mcu_flush` im `assert_no_pause()`-Kontext wo `flush_step_generation()` verboten ist. Ein Move auf unsynchronisierten Cursor → erneut Invalid sequence.
Fix: `_exit_overflow()` setzt `_needs_overflow_prime=True`. `_main_tick()` submitted im sicheren Reaktor-Kontext (`forced_t0=None`) einen 0.05mm-Anchor-Move zur Cursor-Synchronisation. `_on_mcu_flush` überspringt das Submit solange das Flag gesetzt ist.

**3. `flush_callback_chunk_mm`**
`_on_mcu_flush` verwendete `max_move_chunk_mm` (50mm) → Feeder überschoss den HALL1-Overflow-Bereich → Motor schleift.
Fix: Eigener Parameter `flush_callback_chunk_mm` (Default 15mm = HALL3→HALL2-Pufferweg Mellow LLL Plus). `lll.cfg` entsprechend ergänzt.

## Begleitende Änderungen

- `lll.cfg`: `use_flush_callback_bang_bang: True` und `flush_callback_chunk_mm: 15.0` ergänzt

## Abhängigkeiten

Setzt P7-52 (`use_flush_callback_bang_bang`) voraus. Alle drei Fixes sind notwendig — keiner allein verhindert den Crash zuverlässig.

Hardware-validiert: 292 OVERFLOW-Events, 0 Invalid-sequence-Crashes.
TDD: 12 neue Tests (`test_t0_enable_floor.py` + `test_overflow_prime.py`), alle grün.