### PR TITLE
fix(buffer_feeder): Akkumulator-Reset beim Start jeder neuen Feed-Session

### DIFF
--- a/klipper_extras/buffer_feeder.py
+++ b/klipper_extras/buffer_feeder.py
@@ -2083,6 +2083,14 @@ class BufferFeeder:
             # Buffer leer: feed. step_gen_time + lead_time is the
             # safe anchor — Klipper just told us the cursor is here.
             if not self._continuous_feed:
+                # P7-57: Reset safety-distance counter on every new
+                # feed session (first chunk after a hall_empty edge).
+                # Without this the accumulator carries over distance
+                # from the previous print and may trip JAM_SAFETY_
+                # DISTANCE at the start of the next print — hardware-
+                # validated: two successive prints (~3873 mm each),
+                # no false JAM_SAFETY_DISTANCE trigger.
+                self._feed_distance_accumulator = 0.0
                 anchor = step_gen_time + self.lead_time
                 self._submit_move(self.flush_callback_chunk_mm,
                                    self.feed_speed,


### PR DESCRIPTION
## Problem

`_feed_distance_accumulator` in `_on_mcu_flush` wird nicht zurückgesetzt wenn eine neue Feed-Session beginnt (erster Chunk nach einer `hall_empty`-Aktivierung). Der Zähler erbt die akkumulierte Distanz des Vordrucks und kann `JAM_SAFETY_DISTANCE` bereits kurz nach dem nächsten Druckstart auslösen — obwohl kein echter Jam vorliegt.

## Fix

`self._feed_distance_accumulator = 0.0` wird jetzt im `if not self._continuous_feed:` Block in `_on_mcu_flush` einmalig pro Session ausgeführt — genau beim Übergang von passiv zu aktiv (erster Chunk).

```python
if not self._continuous_feed:
    # P7-57: Reset safety-distance counter on every new feed session
    self._feed_distance_accumulator = 0.0
    anchor = step_gen_time + self.lead_time
    self._submit_move(...)
```

## Abhängigkeiten

Keine — unabhängige Änderung, orthogonal zu PR für P7-61.

## Hardware-Validierung

Zwei aufeinanderfolgende Drucke (~3873 mm Filament je Druck) auf Mellow LLL Plus mit `use_flush_callback_bang_bang: True`. Kein `JAM_SAFETY_DISTANCE`-Abbruch, keine sonstigen Feeder-Fehler.