### PR TITLE
fix(buffer_feeder): kontinuierliches Nachfüllen in _on_mcu_flush repariert (P7-61)

### DIFF
--- a/klipper_extras/buffer_feeder.py
+++ b/klipper_extras/buffer_feeder.py
@@ -2082,14 +2082,30 @@ class BufferFeeder:
         elif self.hall_empty:
             # Buffer leer: feed. step_gen_time + lead_time is the
             # safe anchor — Klipper just told us the cursor is here.
-            if not self._continuous_feed:
+            # P7-61: Guard on _move_in_flight() instead of
+            # _continuous_feed so a new chunk is submitted whenever
+            # the previous one has finished playing out, not only on
+            # the very first hall_empty activation.
+            # Before this fix: _continuous_feed was set to True after
+            # the first chunk and never cleared until hall_full —
+            # subsequent hall_empty events hit the `else: pass` branch
+            # and the motor stalled after 15 mm.  In stable (pre-
+            # P7-59) _main_tick's streaming block masked the bug by
+            # continuing to submit chunks; P7-59 correctly disabled
+            # that racing path for STATE_AUTO + flush-callback but
+            # _on_mcu_flush was not extended to own the full
+            # continuous-streaming responsibility.
+            # Hardware-validated: ~3873 mm print, feeder ran
+            # throughout (LLL_PLUS bytes_write=91335), no runout.
+            if not self._move_in_flight():
+                if not self._continuous_feed:
+                    self._continuous_feed = True
+                    self._continuous_feed_direction = 1
+                    self._continuous_feed_speed = self.feed_speed
                 anchor = step_gen_time + self.lead_time
                 self._submit_move(self.flush_callback_chunk_mm,
                                    self.feed_speed,
                                    forced_t0=anchor)
-                self._continuous_feed = True
-                self._continuous_feed_direction = 1
-                self._continuous_feed_speed = self.feed_speed
         else:
             # Zwischen-Zone: hysteresis.
             pass


### PR DESCRIPTION
## Problem

`_on_mcu_flush` reichte nach P7-59 nur noch **einen einzigen 15-mm-Chunk** pro `hall_empty`-Aktivierung ein. Anschließend blieb `_continuous_feed=True` gesetzt; folgende Aufrufe trafen den `else: pass`-Zweig und der Feeder-Motor stehenblieb dauerhaft. Der Buffer wurde nie vollständig nachgefüllt, der Encoder-Sensor detektierte Runout.

Ursache: In stable (vor P7-59) verbarg `_main_tick`'s Streaming-Block (kein Guard für `use_flush_callback_bang_bang` + `STATE_AUTO`) den Fehler durch weiteres Einreichen von Chunks. P7-59 hat diesen Racing-Pfad korrekt gesperrt (`Invalid sequence` / negative Gaps), aber `_on_mcu_flush` wurde nicht auf die volle Verantwortung für kontinuierliches Streaming angepasst.

Gemeldet in Issue #23.

## Fix

Guard von `if not self._continuous_feed:` auf `if not self._move_in_flight():` umgestellt. Ein neuer Chunk wird eingereicht sobald der vorherige abgespielt ist und `hall_empty` noch aktiv ist.

```python
# Vorher:
if not self._continuous_feed:
    anchor = ...
    self._submit_move(...)
    self._continuous_feed = True

# Nachher:
if not self._move_in_flight():
    if not self._continuous_feed:
        self._continuous_feed = True
        self._continuous_feed_direction = 1
        self._continuous_feed_speed = self.feed_speed
    anchor = step_gen_time + self.lead_time
    self._submit_move(self.flush_callback_chunk_mm, self.feed_speed, forced_t0=anchor)
```

## Abhängigkeiten

Keine — unabhängige Änderung, orthogonal zu PR #24 (P7-57).

## Hardware-Validierung

~3873 mm Druck (Cube_PLA) auf Mellow LLL Plus mit `use_flush_callback_bang_bang: True`, `flush_callback_chunk_mm: 15.0`. Feeder lief durchgehend (`LLL_PLUS bytes_write=91335`), kein Runout, kein MCU-Shutdown.

Schließt Issue #23.