### PR TITLE
C-cont Hotfix 7 — Soft-Throttle (verbrauchskonforme Feeder-Geschwindigkeit)

### DIFF
--- a/docs/superpowers/plans/2026-05-13-c-cont-hotfix7-soft-throttle.md
+++ b/docs/superpowers/plans/2026-05-13-c-cont-hotfix7-soft-throttle.md
@@ -1,0 +1,415 @@
+# C-cont Hotfix 7 — Soft-Throttle (Implementation Plan)
+
+> **TDD-Workflow (Regel #7):** Tests ZUERST. Jede Task durchläuft fest 5 Steps: 1) Tests schreiben → 2) pytest erwartet RED → 3) Code minimal implementieren → 4) pytest erwartet GREEN → 5) Full-Suite pytest grün, keine Regressionen.
+
+**Spec:** `docs/superpowers/specs/2026-05-13-c-cont-hotfix7-soft-throttle.md`
+**Branch-Basis:** `feature/c-cont-streaming` HEAD (Hotfix 6, MD5 `f18a28ef290784aaf8a24ab046fdabb3`)
+**Code-Review:** code-reviewer Subagent nach Task 3 (Phase 4 vor Hardware-Upload)
+**Ziel-LOC:** Modulator-Funktion ~30 Zeilen, ~10 neue Tests, ~5 Updates an bestehenden Tests
+
+---
+
+## File Structure
+
+**Modified:**
+- `klipper_extras/buffer_feeder.py`
+  - Methode `SpeedModulator._compute_target_feed_speed` (Z. 2731-2753)
+  - Inline-Kommentar-Block über der Methode (Hotfix7-Doku, Maintainer-Stil, Regel #8)
+
+**Modified (Tests):**
+- `tests/test_c_cont_streaming.py`
+  - Bestehende Tests die `30.0` als HALL3-Wert erwarten: 5 Tests updaten oder neu schreiben
+  - 10 neue Tests für Hotfix7 hinzufügen
+
+**Keine neuen Files** (kompakter Hotfix, kein Architektur-Umbau).
+
+---
+
+## Task 1 — Test-Suite erweitern + bestehende Tests anpassen
+
+**Files:** `tests/test_c_cont_streaming.py`
+
+### Step 1 — Tests schreiben (RED erwartet)
+
+**1.1 Neue Hotfix7-Tests hinzufügen** (Block nach Z.387, nach bestehenden Hotfix6-Tests einfügen):
+
+```python
+# ---------------------------------------------------------------------------
+# C-cont Hotfix 7 (Hardware 2026-05-13 klippy.log Z.104571, c=12 i=0 nach
+# 16+ HALL1-OVERFLOW-Zyklen). Soft-Throttle: Feeder-Speed skaliert mit
+# Extruder-Verbrauch statt fix 30 mm/s. Adressiert Hardware-Geometrie
+# (HALL2->HALL1 nur 3.6mm Sicherheitsmarge vs 5mm-Chunk-Schwung-Energie).
+# Siehe specs/2026-05-13-c-cont-hotfix7-soft-throttle.md
+# ---------------------------------------------------------------------------
+
+
+def test_c_cont_hotfix7_hall3_high_vel_capped_at_feed_speed(monkeypatch):
+    """Hotfix7: HALL3:on + vel=25 -> max(25*1.5=37.5, 15) capped auf
+    feed_speed=30. Soft-Cap verhindert ueberzogene Speeds bei schnellen
+    Drucken."""
+    printer, feeder = make_c_cont_feeder(monkeypatch)
+    set_sensor_active(feeder, 'hall_empty', True)
+    set_sensor_active(feeder, 'hall_full', False)
+    set_sensor_active(feeder, 'hall_overflow', False)
+    _populate_tracker_to_ready(feeder, velocity=25.0)
+    # 25*1.5=37.5 > feed_speed=30 -> capped to 30
+    assert feeder._compute_target_feed_speed() == pytest.approx(30.0, abs=0.1)
+
+
+def test_c_cont_hotfix7_hall3_mid_vel_scales_with_extruder(monkeypatch):
+    """Hotfix7: HALL3:on + vel=15 -> max(15*1.5=22.5, 15)=22.5.
+    Scaling mit Verbrauch statt fixe 30 mm/s -> halbierte Schwung-Energie
+    bei moderaten Drucken."""
+    printer, feeder = make_c_cont_feeder(monkeypatch)
+    set_sensor_active(feeder, 'hall_empty', True)
+    set_sensor_active(feeder, 'hall_full', False)
+    set_sensor_active(feeder, 'hall_overflow', False)
+    _populate_tracker_to_ready(feeder, velocity=15.0)
+    assert feeder._compute_target_feed_speed() == pytest.approx(22.5, abs=0.1)
+
+
+def test_c_cont_hotfix7_hall3_low_vel_uses_min_floor(monkeypatch):
+    """Hotfix7: HALL3:on + vel=8 (unter MIN_FLOOR) -> 15 mm/s
+    (MIN_FLOOR-Boden). 8*1.5=12 < 15 -> Floor wins."""
+    printer, feeder = make_c_cont_feeder(monkeypatch)
+    set_sensor_active(feeder, 'hall_empty', True)
+    set_sensor_active(feeder, 'hall_full', False)
+    set_sensor_active(feeder, 'hall_overflow', False)
+    _populate_tracker_to_ready(feeder, velocity=8.0)
+    assert feeder._compute_target_feed_speed() == pytest.approx(15.0, abs=0.1)
+
+
+def test_c_cont_hotfix7_hall3_vel_zero_uses_min_floor(monkeypatch):
+    """Hotfix7: HALL3:on + tracker ready aber vel=0 (Toolhead stalled
+    mit leerem Buffer) -> 15 mm/s. Buffer muss trotz Stall gefuellt
+    werden, aber sanft (MIN_FLOOR statt 30)."""
+    printer, feeder = make_c_cont_feeder(monkeypatch)
+    set_sensor_active(feeder, 'hall_empty', True)
+    set_sensor_active(feeder, 'hall_full', False)
+    set_sensor_active(feeder, 'hall_overflow', False)
+    # Tracker ready aber vel=0
+    fake_ext = feeder.printer.objects['extruder']
+    t = 0.0
+    for _ in range(12):
+        fake_ext.last_position = 100.0  # konstant -> vel=0
+        feeder.velocity_tracker.tick(t)
+        t += 0.025
+    assert feeder.velocity_tracker.is_ready()
+    assert feeder.velocity_tracker.get_velocity() == 0.0
+    assert feeder._compute_target_feed_speed() == pytest.approx(15.0, abs=0.1)
+
+
+def test_c_cont_hotfix7_hall3_tracker_not_ready_uses_min_floor(monkeypatch):
+    """Hotfix7: HALL3:on + tracker noch nicht ready (Print-Start) ->
+    15 mm/s. Vorher Hotfix6: 30 mm/s -> aggressiver Initial-Fill ->
+    HALL1-Overshoot waehrend velocity_tracker noch sammelt."""
+    printer, feeder = make_c_cont_feeder(monkeypatch)
+    set_sensor_active(feeder, 'hall_empty', True)
+    set_sensor_active(feeder, 'hall_full', False)
+    set_sensor_active(feeder, 'hall_overflow', False)
+    assert not feeder.velocity_tracker.is_ready()
+    assert feeder._compute_target_feed_speed() == pytest.approx(15.0, abs=0.1)
+
+
+def test_c_cont_hotfix7_zwischen_low_vel_zero(monkeypatch):
+    """Hotfix7: Zwischenzone + vel<MIN_FLOOR -> 0.0 (unveraendert
+    von Hotfix5: vermeidet Submits bei Spurious-Buffer-Drift)."""
+    printer, feeder = make_c_cont_feeder(monkeypatch)
+    set_sensor_active(feeder, 'hall_empty', False)
+    set_sensor_active(feeder, 'hall_full', False)
+    set_sensor_active(feeder, 'hall_overflow', False)
+    _populate_tracker_to_ready(feeder, velocity=5.0)
+    assert feeder._compute_target_feed_speed() == 0.0
+
+
+def test_c_cont_hotfix7_zwischen_high_vel_capped(monkeypatch):
+    """Hotfix7: Zwischenzone + vel=40 -> min(40*1.10=44, feed_speed=30)=30.
+    NEUER Soft-Cap in Zwischenzone (vorher: unbounded vel*1.10).
+    Verhindert dass schnelle Drucke target_speed > feed_speed setzen."""
+    printer, feeder = make_c_cont_feeder(monkeypatch)
+    set_sensor_active(feeder, 'hall_empty', False)
+    set_sensor_active(feeder, 'hall_full', False)
+    set_sensor_active(feeder, 'hall_overflow', False)
+    _populate_tracker_to_ready(feeder, velocity=40.0)
+    assert feeder._compute_target_feed_speed() == pytest.approx(30.0, abs=0.1)
+
+
+def test_c_cont_hotfix7_zwischen_tracker_not_ready_zero(monkeypatch):
+    """Hotfix7: Zwischenzone + tracker not_ready -> 0.0 (unveraendert
+    von Hotfix4: nur HALL3:on darf bei not_ready foerdern, alle anderen
+    Zonen warten auf echte Velocity)."""
+    printer, feeder = make_c_cont_feeder(monkeypatch)
+    set_sensor_active(feeder, 'hall_empty', False)
+    set_sensor_active(feeder, 'hall_full', False)
+    set_sensor_active(feeder, 'hall_overflow', False)
+    assert not feeder.velocity_tracker.is_ready()
+    assert feeder._compute_target_feed_speed() == 0.0
+
+
+def test_c_cont_hotfix7_hall2_zero_regression(monkeypatch):
+    """Regression: HALL2:on -> 0.0 (unveraendert von Hotfix5).
+    Stellt sicher dass Hotfix7-Umbau den HALL2-Pfad nicht bricht."""
+    printer, feeder = make_c_cont_feeder(monkeypatch)
+    set_sensor_active(feeder, 'hall_empty', False)
+    set_sensor_active(feeder, 'hall_full', True)
+    set_sensor_active(feeder, 'hall_overflow', False)
+    _populate_tracker_to_ready(feeder, velocity=20.0)
+    assert feeder._compute_target_feed_speed() == 0.0
+
+
+def test_c_cont_hotfix7_hall1_zero_regression(monkeypatch):
+    """Regression: HALL1:on -> 0.0 (Notbremse). Stellt sicher dass
+    Hotfix7-Umbau den OVERFLOW-Pfad nicht beeinflusst."""
+    printer, feeder = make_c_cont_feeder(monkeypatch)
+    set_sensor_active(feeder, 'hall_overflow', True)
+    set_sensor_active(feeder, 'hall_empty', False)
+    set_sensor_active(feeder, 'hall_full', False)
+    _populate_tracker_to_ready(feeder, velocity=20.0)
+    assert feeder._compute_target_feed_speed() == 0.0
+```
+
+**1.2 Bestehende Hotfix6-Tests anpassen** (5 Tests):
+
+| Test (Zeile) | Bisheriger Erwartungswert | Neuer Erwartungswert | Begründung |
+|---|---|---|---|
+| `test_c_cont_modulator_hall3_max` (Z.154) | `== 30.0` mit vel=15 | `== pytest.approx(22.5, abs=0.1)` | 15*1.5=22.5 (Soft-Throttle) |
+| `test_c_cont_hotfix4_stalled_but_hall_empty_still_fills` (Z.257) | `== 30.0` mit vel=0 | `== pytest.approx(15.0, abs=0.1)` | MIN_FLOOR-Pfad |
+| `test_c_cont_hotfix4_not_ready_but_hall_empty_uses_fallback` (Z.288) | `== 30.0` mit not_ready | `== pytest.approx(15.0, abs=0.1)` | MIN_FLOOR-Pfad |
+| `test_c_cont_hotfix6_hall3_uses_30_not_feed_speed` (Z.376) | `== 30.0` | **Test umschreiben** als `test_c_cont_hotfix7_hall3_scales_with_vel` | Hotfix6 ist obsolet |
+| `test_c_cont_hotfix6_hall3_speed_constant_30` (Z.919) | `== 30.0` zweimal | **Test umschreiben** als `test_c_cont_hotfix7_hall3_speed_varies_with_vel` | Hotfix6 ist obsolet |
+| `test_c_cont_hotfix3_zwischen_soft_floor_high_vel` (Z.319) | `== pytest.approx(55.0)` für vel=50 | `== pytest.approx(30.0)` | NEUER Soft-Cap (feed_speed=30) |
+
+Jeder Test bekommt einen Kommentar `# Hotfix7-Update:` mit kurzer Begründung.
+
+### Step 2 — pytest erwartet RED
+
+```bash
+cd D:/Entwicklung/LLL-Python/Repo
+python -m pytest tests/test_c_cont_streaming.py -v -k "hotfix7 or modulator_hall3_max or hotfix4_stalled_but_hall_empty or hotfix4_not_ready_but_hall_empty or hotfix6_hall3 or hotfix3_zwischen_soft_floor_high_vel"
+```
+
+- [ ] **Erwartung:** 10 neue Tests FAIL (assertion error, Methode liefert noch alte Werte), 4-5 Update-Tests FAIL (alter Wert vs neuer Erwartungswert). Alle anderen Tests grün.
+
+### Step 3 — Code implementieren
+
+`klipper_extras/buffer_feeder.py`, Methode `_compute_target_feed_speed` in `SpeedModulator` (Z. 2731-2753) ersetzen:
+
+```python
+def _compute_target_feed_speed(self):
+    # C-cont Hotfix7 (Hardware-Crash 2026-05-13 klippy.log Z.104571,
+    # c=12 i=0 Invalid sequence nach 16+ HALL1-OVERFLOW-Zyklen in
+    # 80s). Wurzel: Hardware-Geometrie (optische Lichtschranken,
+    # HALL3<->HALL2 = 12.8mm, HALL2<->HALL1 = 3.6mm, Ausloeser-
+    # Fahne 3-4mm, Hebel 2:1) + Hotfix6's 5mm-Chunk @ 30 mm/s
+    # injiziert Schwung-Energie die den Arm systematisch ueber
+    # HALL2 katapultiert. HALL2->HALL1 in nur 3.6mm (=120ms bei
+    # 30 mm/s) < Flush-Tick-Reaktionszeit (~250-500ms). Software
+    # strukturell zu langsam, ergo Schwung-Energie muss runter.
+    #
+    # Soft-Throttle: target_speed skaliert mit Extruder-Verbrauch:
+    #   HALL3:on, vel>=MIN_FLOOR:   max(vel*1.5, MIN_FLOOR), cap feed_speed
+    #   HALL3:on, vel<MIN_FLOOR:    MIN_FLOOR (Initial-Boost / Idle)
+    #   HALL3:on, not ready:        MIN_FLOOR (Print-Start)
+    #   Zwischenzone, vel>=MIN_FLOOR: min(vel*1.10, feed_speed)
+    #   Zwischenzone, vel<MIN_FLOOR oder not ready: 0
+    #   HALL2:on:                   0 (Hotfix5, unveraendert)
+    #   HALL1:on:                   0 (Notbremse, unveraendert)
+    #
+    # Hotfix6 (vorher): HALL3:on -> 30 mm/s fix. Bei niedriger
+    # Print-Geschwindigkeit injiziert das 6x Verbrauch -> Buffer-
+    # Arm-Overshoot HALL2->HALL1 (siehe Hardware-Beleg oben).
+    # Hotfix7 koppelt Push an Bedarf: bei vel=5 schiebt Feeder
+    # nur 15 mm/s (statt 30) -> halbierte Schwung-Energie ->
+    # Arm bremst in HALL2-Sicherheitsfenster ab.
+    #
+    # Soft-Cap auf feed_speed (NEU vs Hotfix3): verhindert dass
+    # vel*1.5 oder vel*1.10 bei schnellen Drucken target_speed
+    # ueber die konfigurierte Obergrenze treibt. Hardware-sicher
+    # weil feed_speed im cfg bereits hardware-validiert ist.
+    MIN_FLOOR = 15.0  # mm/s, ererbt von Hotfix3 (validated baseline)
+
+    if self.hall_overflow:
+        return 0.0
+    if self.hall_full:
+        return 0.0  # Hotfix5: HALL2 = Buffer voll, kein Push
+
+    vel_ready = self.velocity_tracker.is_ready()
+    vel = self.velocity_tracker.get_velocity() if vel_ready else 0.0
+
+    if self.hall_empty:
+        # HALL3:on -> Buffer leer, Auffuellen mit 50% Margin
+        if not vel_ready or vel < MIN_FLOOR:
+            return MIN_FLOOR
+        return min(max(vel * 1.5, MIN_FLOOR), self.feed_speed)
+
+    # Zwischenzone (kein HALL aktiv)
+    if not vel_ready or vel < MIN_FLOOR:
+        return 0.0
+    return min(vel * 1.10, self.feed_speed)
+```
+
+- [ ] **Code-Block einfügen.** Alten Block (Hotfix6) komplett ersetzen.
+
+### Step 4 — pytest erwartet GREEN
+
+```bash
+python -m pytest tests/test_c_cont_streaming.py -v -k "hotfix7 or modulator_hall3 or hotfix4_stalled or hotfix4_not_ready or hotfix3_zwischen_soft_floor_high_vel"
+```
+
+- [ ] **Erwartung:** Alle 14-15 modifizierten/neuen Tests grün.
+
+### Step 5 — Full-Suite pytest
+
+```bash
+python -m pytest tests/ -v
+```
+
+- [ ] **Erwartung:** Gesamte Test-Suite grün. Falls Regressionen: STOP, root-cause Investigation per superpowers:systematic-debugging.
+
+---
+
+## Task 2 — Code-Review via code-reviewer Subagent (Phase 4)
+
+**Voraussetzung:** Task 1 komplett, alle Tests grün.
+
+### Step 1 — Git-Commit lokal (Hotfix7 in Working-Copy)
+
+```bash
+cd D:/Entwicklung/LLL-Python/Repo
+git status   # Erwartung: 2 Files modified (buffer_feeder.py, test_c_cont_streaming.py)
+git diff --stat
+```
+
+- [ ] **Verifikation:** Nur die 2 Files erscheinen, Diff-Size plausibel (~30 LOC Code, ~150 LOC Tests).
+
+### Step 2 — Diff für Reviewer vorbereiten
+
+Reviewer-Agent erhält:
+- Spec-Pfad: `docs/superpowers/specs/2026-05-13-c-cont-hotfix7-soft-throttle.md`
+- Plan-Pfad: `docs/superpowers/plans/2026-05-13-c-cont-hotfix7-soft-throttle.md`
+- BASE_SHA = aktueller `feature/c-cont-streaming` HEAD (Hotfix6)
+- HEAD_SHA = lokaler Working-Copy-Commit
+
+### Step 3 — code-reviewer Subagent dispatchen
+
+Via Agent-Tool, subagent_type='superpowers:code-reviewer'. Prompt enthält:
+- Was implementiert wurde (Soft-Throttle, Hardware-Geometrie-driven Refactor)
+- Plan-Referenz (Pfad)
+- Spec-Referenz (Pfad)
+- Git BASE/HEAD SHAs
+- Beschreibung der Hardware-Wurzel-Analyse
+
+### Step 4 — Findings adressieren
+
+- [ ] **Critical** → sofort fix vor Hardware-Test
+- [ ] **Important** → fix vor Hardware-Test (Standard)
+- [ ] **Minor** → in Backlog, optional inline-fix
+
+Bei push-back: User-Diskussion ob Reviewer-Feedback berechtigt.
+
+### Step 5 — Re-Test nach Findings-Fixes
+
+```bash
+python -m pytest tests/ -v
+```
+
+- [ ] **Erwartung:** weiter grün.
+
+---
+
+## Task 3 — Fork-Commit (Regel #9)
+
+**Voraussetzung:** Task 2 fertig, Code-Review-Findings adressiert.
+
+### Step 1 — Commit-Message vorbereiten
+
+Maintainer-Stil, basierend auf Vorlage in Spec Kap. 8:
+- Hardware-Beleg zitiert (klippy.log Z.104571, c=12 i=0)
+- Wurzel benannt (Hardware-Geometrie + Pipeline-Energie)
+- Fix-Logik erklärt (Soft-Throttle, Skalierung mit vel)
+- Test-Count (vor: N → nach: N+10 minus 2 ersetzt = N+8)
+
+### Step 2 — Branch-Wahl
+
+Branch: `feature/c-cont-streaming` (gleicher Branch, weiterer Commit)
+
+### Step 3 — Commit + Push
+
+```bash
+git add klipper_extras/buffer_feeder.py tests/test_c_cont_streaming.py docs/superpowers/specs/2026-05-13-c-cont-hotfix7-soft-throttle.md docs/superpowers/plans/2026-05-13-c-cont-hotfix7-soft-throttle.md
+git commit -m "..." # Heredoc mit Maintainer-Format
+git push origin feature/c-cont-streaming
+```
+
+- [ ] **Verifikation:** Push erfolgreich, Commit-SHA notieren.
+
+---
+
+## Task 4 — Hardware-Test (Phase 5)
+
+**Voraussetzung:** Task 3 fertig, Fork-Commit pushed.
+
+### Step 1 — Upload buffer_feeder.py auf Drucker
+
+```bash
+cat "D:/Entwicklung/LLL-Python/Repo/klipper_extras/buffer_feeder.py" | \
+  "C:\Program Files\PuTTY\plink.exe" -pw "Je040280-+" -batch pi@192.168.40.3 \
+  "cat > /home/pi/BufferPLUS-klipper/klipper_extras/buffer_feeder.py"
+```
+
+### Step 2 — MD5-Verifikation
+
+```bash
+plink -pw "Je040280-+" -batch pi@192.168.40.3 \
+  "md5sum /home/pi/BufferPLUS-klipper/klipper_extras/buffer_feeder.py"
+```
+
+Lokaler MD5 vergleichen mit:
+```bash
+md5sum D:/Entwicklung/LLL-Python/Repo/klipper_extras/buffer_feeder.py
+```
+
+- [ ] **Erwartung:** MD5 identisch.
+
+### Step 3 — Klipper-Neustart
+
+```bash
+plink -pw "Je040280-+" -batch pi@192.168.40.3 "sudo systemctl restart klipper"
+```
+
+### Step 4 — Druckbett-Frage an User (Regel #5)
+
+- [ ] **Frage:** "Ist das Druckbett frei?"
+- [ ] **Auf Bestätigung warten** — nicht ohne Bestätigung weitermachen.
+
+### Step 5 — User startet Druck, Beobachtung
+
+User startet Feedertest.gcode. Erwartete Erfolgs-Kriterien:
+- ≤2 HALL1-OVERFLOW-Zyklen über 4min Print (statt 16+)
+- Kein `stepcompress c=N i=0 Invalid sequence` Crash
+- `target_speed` in buffer_metrics korreliert mit `tracker_vel`
+
+### Step 6 — Log analysieren (egal ob Erfolg oder Crash)
+
+```bash
+"C:\Program Files\PuTTY\plink.exe" -pw "Je040280-+" -batch pi@192.168.40.3 \
+  "cat /home/pi/printer_data/logs/klippy.log" > "D:\Entwicklung\LLL-Python\klippy.log"
+```
+
+- [ ] **Bei Erfolg:** Erfolgs-Bericht an User, Memory-Update (Hotfix7 hardware-validated)
+- [ ] **Bei Crash:** `superpowers:systematic-debugging` Phase 1 → Crash-Analyse, KEIN Quick-Fix
+
+---
+
+## Risiko-Management
+
+**Iron-Law-Reminder:** Nach 3 fehlgeschlagenen Fixes (Hotfix4, 5, 6 zählen als bisherige Versuche) → Architektur-Frage stellen, KEIN weiterer Hotfix8 ohne Diskussion mit User.
+
+**Aktueller Stand:** Hotfix7 ist Versuch 4 in der C-cont-Serie unter feature/c-cont-streaming. Wenn Hotfix7 die HALL1-Overshoot nicht ausreichend reduziert (z.B. nur 16 → 10 Zyklen statt 16 → 2), ist das ein **klares Signal** für Architektur-Diskussion (z.B. Wechsel zu prädiktivem Ansatz aus High-Flow-Spec, oder Hardware-Geometrie-Anpassung).
+
+---
+
+## Pending User-Approvals
+
+- [x] Spec freigegeben (Phase 1 abgeschlossen)
+- [ ] **Plan freigegeben → Phase 3 (TDD-Implementation) starten?**

--- a/docs/superpowers/specs/2026-05-13-c-cont-hotfix7-soft-throttle.md
+++ b/docs/superpowers/specs/2026-05-13-c-cont-hotfix7-soft-throttle.md
@@ -1,0 +1,257 @@
+# C-cont Hotfix 7 — Soft-Throttle (Verbrauchskonforme Feeder-Geschwindigkeit)
+
+**Datum:** 2026-05-13
+**Branch-Basis:** `feature/c-cont-streaming` HEAD (Hotfix 6, MD5 `f18a28ef290784aaf8a24ab046fdabb3`)
+**Status:** Spec — pending User-Approval vor Phase 2 (Plan)
+**Vorgänger-Spec:** `2026-05-13-high-flow-buffer-architecture.md` (allgemeine C-cont Vision)
+
+---
+
+## 1. Problem-Statement
+
+### Hardware-Crash 2026-05-13
+Feedertest.gcode Druck, reine Druckzeit 4min 11sec, Crash:
+```
+Z.104571: b'stepcompress o=0 i=0 c=12 a=0: Invalid sequence'
+Z.104572: b"Error in syncemitter 'mellow' step generation"
+Z.104573-79: Exception in flush_handler → mcu.error: Internal error in stepcompress
+Z.104580: Transition to shutdown state
+```
+Hotfix 6 (HALL3 hardcoded 30 mm/s, HALL2 → 0, MIN_FLOOR=15 vel-Skip) lief seit Boot.
+
+### Beobachtetes Pattern direkt vor Crash
+80 Sekunden vor dem Crash: **16+ HALL1-OVERFLOW-Zyklen** (alle ~2s ein voller AUTO→OVERFLOW→IDLE→AUTO).
+Letzte 5 Sekunden (Z.104560 – 104570):
+```
+target_speed-Sequenz: 30 → 0 → 0 → 0 → 30 → 18.7 → CRASH
+HALL-State-Sequenz:    H3:on → off → off → off → H3:on → off → CRASH
+tracker_vel:           8.7 → 8.0 → 11.5 → 7.5 → 7.2 → 17.0 mm/s
+```
+
+### Hardware-Geometrie (User-vermessen 2026-05-13)
+- **Sensor-Typ:** optische Lichtschranken (KEINE Hall-Magnete trotz Codename `HALL`)
+- **HALL3 ↔ HALL2 Abstand:** ~12.8 mm
+- **HALL2 ↔ HALL1 Abstand:** ~3.6 mm
+- **Arm-Auslöser (Fahne):** 3–4 mm Länge
+- **Mechanischer Hebel:** ~2:1 (5mm Filament-Push → 2.5mm Arm-Deflektion via Schlaufe)
+- **Voller Hub HALL3-Zone → HALL1:** 16.4 mm = entspricht ~32.8mm Filament-Push
+
+### Direkte Beobachtung
+Z.104017 – 104020 (Erst-OVERFLOW nach Print-Start):
+```
+t=0:   buffer_metrics: H3:on H2:off H1:off  vel=3.2  target=30  (HALL3-Bouncing)
+t=+1s: buffer_metrics: H3:off H2:off H1:off vel=3.4  target=0   (Zwischenzone, Submit pausiert)
+t=+2s: HALL1 OVERFLOW
+       buffer_metrics: H3:off H2:on  H1:off vel=3.4  target=0   (HALL2 erst NACH dem HALL1-Edge)
+```
+
+→ Arm bewegte sich **trotz target=0** über die volle Hub-Strecke. Energie kam aus dem vorhergehenden 5mm-Chunk @ 30 mm/s. HALL2 wurde im Polling übersprungen (Auslöser-Geometrie + Polling-Aliasing).
+
+---
+
+## 2. Wurzel-Ursachen
+
+### Wurzel 1 — Mechanische Schwung-Energie (PRIMÄR)
+`interrupt_chunk_mm = 5` Filament-Push @ `feed_speed = 30 mm/s` injiziert pro Submit:
+- 5 mm Filament-Energie → 2.5 mm Arm-Deflektion via Schlaufen-Hebel
+- ~167 ms Chunk-Dauer mit accel/decel-Trapezoid (Schwung wird mitgegeben)
+- Arm bewegt sich mechanisch weiter nach Submit-Ende (Trägheit + verbleibender Filament-Druck)
+
+Bei nur **3.6mm HALL2→HALL1 Sicherheitsmarge** und Software-Reaktionszeit (Flush-Tick 250-500ms) ist die Software **strukturell zu langsam**, um den Arm vor HALL1 zu stoppen, sobald HALL3 freigegeben wurde.
+
+### Wurzel 2 — Speed-Hopping triggert State-Drift (SEKUNDÄR)
+Hotfix6's Logik (`HALL3 → 30`, Zwischenzone vel<15 → 0, vel≥15 → vel*1.10) erzeugt im normalen Pendel-Betrieb rapide Speed-Wechsel: `30 → 0 → 30 → 18.7 → 0 → 30...`. Jede target=0-Phase pausiert die Pipeline, jeder Wiederstart erzeugt einen neuen forced_t0-Anchor. Über 16+ OVERFLOW-Zyklen sammelt sich State-Drift (`_last_move_end_time`, `_stepcompress_primed`, `_continuous_feed`-Flags) bis zum Race.
+
+### Wurzel 3 — HALL1-Storm belastet State-Machine (TERTIÄR)
+Jeder HALL1-Trigger durchläuft: `_enter_overflow` → `_halt_motion` → `OVERFLOW → IDLE → AUTO` → `_resume_after_overflow`. Bei 16+ Zyklen pro Minute akkumulieren sich Race-Chancen in genau diesem Pfad. Patches P7-71, P7-72, P7-77B haben drei bekannte stale-anchor-Pfade abgesichert, aber unter Hotfix6's neuem Speed-Switching tritt offensichtlich ein vierter Pfad zutage.
+
+---
+
+## 3. Optionen-Vergleich
+
+### Option A — Kleinere Chunks (`interrupt_chunk_mm`: 5 → 2)
+Reduziert Energie pro Submit. Aber: bei niedrigen Chunk-Distanzen dominiert accel/decel-Phase (Triangular-Profile) → tatsächliche max-Geschwindigkeit sinkt unter feed_speed. Höhere Pipeline-Last (mehr Submits/sec → mehr State-Transitions → mehr Race-Chancen). Adressiert nur Wurzel 1, nicht Wurzel 2/3.
+
+### Option B — Geschwindigkeits-Rampe (HALL3:on → 10 → 20 → 30 mm/s über 1s)
+Begrenzt Schwung-Aufbau in der HALL3→HALL2-Annäherung. Aber: erfordert neue Zustands-Variablen (`_hall_empty_start_time`), kompliziert die Modulator-Logik, braucht Schwellenwert-Tuning, bei hochflussigem Druck kann der Buffer leerlaufen bevor die Rampe hochfährt.
+
+### Option C — Soft-Throttle (verbrauchskonform) — **GEWÄHLT**
+Feeder-Geschwindigkeit skaliert mit Extruder-Verbrauch:
+```
+HALL3:on, vel ≥ MIN_FLOOR:    target = max(vel * 1.5, MIN_FLOOR)    # Auffüllen mit 50% Margin
+HALL3:on, vel < MIN_FLOOR:    target = MIN_FLOOR                    # Initial-Boost / Idle
+Zwischenzone, vel ≥ MIN_FLOOR: target = max(vel * 1.10, MIN_FLOOR)  # bisheriges Hotfix6
+Zwischenzone, vel < MIN_FLOOR: target = 0                           # bisheriges Hotfix6 (skip-Pfad)
+HALL2:on:                     target = 0                            # bisheriges Hotfix5
+HALL1:on:                     OVERFLOW (Notbremse)                  # unverändert
+```
+
+**Begründung:**
+- Adressiert Wurzel 1 strukturell: bei langsamem Print (vel=10 mm/s) schiebt Feeder nur 15 mm/s statt fixe 30 → halbe Schwung-Energie pro Chunk → Arm bremst im HALL2-Sicherheitsfenster ab
+- Reduziert Wurzel 2: target springt nicht mehr 0 ↔ 30, sondern fließt sanft mit `vel`. Speed-Hopping-Amplitude wird kleiner
+- Reduziert Wurzel 3 als Konsequenz von Wurzel 1: weniger HALL1-Trigger → weniger OVERFLOW-Zyklen → weniger State-Drift-Chancen
+- Verwendet bestehende Infrastruktur (`velocity_tracker.is_ready()` + `velocity_tracker.get_velocity()`)
+- Konsistent über alle Hall-Zustände (kein Hardcoded-Sprung mehr)
+
+**Trade-Off:**
+- Bei Print-Start ist `velocity_tracker` noch nicht ready → fällt auf `MIN_FLOOR=15` zurück (akzeptabel für initial Buffer-Auffüllung)
+- Bei Filament-Wechsel mit leerem Buffer: 15 mm/s initial ist langsam, Buffer-Voll-Befüllung dauert ~30s. Mitigation: Buffer-Wiederbefüllung läuft solange HALL3 stable → bei stable HALL3 ohne extruder-vel könnte ein zweiter Threshold den Boost erlauben (für spätere Iteration, nicht in Hotfix7)
+
+---
+
+## 4. Konkrete Code-Änderung
+
+**Datei:** `klipper_extras/buffer_feeder.py`
+**Funktion:** `SpeedModulator._compute_target_feed_speed()` (Z. 2731-2753)
+
+**Aktuell (Hotfix 6):**
+```python
+if self.hall_overflow:
+    return 0.0
+if self.hall_empty:
+    return 30.0  # Hotfix6: HALL3 hardcoded
+if not self.velocity_tracker.is_ready():
+    return self.feed_speed
+vel = self.velocity_tracker.get_velocity()
+if vel == 0:
+    return self.feed_speed
+if self.hall_full:
+    return 0.0  # Hotfix5: HALL2 → 0
+proposed = vel * 1.10
+if proposed < self.MIN_FLOOR:
+    return 0.0  # MIN_FLOOR-Skip
+return proposed
+```
+
+**Hotfix 7 (Soft-Throttle):**
+```python
+# C-cont Hotfix7 (Hardware-Crash 2026-05-13 klippy.log Z.104571,
+# c=12 i=0 Invalid sequence nach 16+ HALL1-OVERFLOW-Zyklen in 80s).
+# Wurzel: Hardware-Geometrie (HALL2→HALL1 nur 3.6mm bei 12.8mm
+# HALL3→HALL2) + 5mm-Chunk @ 30 mm/s Schwung-Energie => Arm
+# überschießt HALL2 systematisch, HALL1-Storm belastet State-
+# Machine bis Stepcompress-Race. Soft-Throttle koppelt
+# feed_speed an extruder_velocity → kein fixer 30 mm/s-Schub
+# mehr, Schwung-Amplitude skaliert mit Print-Bedarf.
+MIN_FLOOR = 15.0  # mm/s (von Hotfix3 übernommen)
+
+if self.hall_overflow:
+    return 0.0
+if self.hall_full:
+    return 0.0  # Hotfix5
+
+vel_ready = self.velocity_tracker.is_ready()
+vel = self.velocity_tracker.get_velocity() if vel_ready else 0.0
+
+if self.hall_empty:
+    # HALL3:on → Buffer leer, Auffüllen mit 50% Margin über Verbrauch
+    if not vel_ready or vel < MIN_FLOOR:
+        return MIN_FLOOR  # Initial-Boost / Idle-Fall
+    return min(max(vel * 1.5, MIN_FLOOR), self.feed_speed)
+
+# Zwischenzone (kein HALL aktiv)
+if not vel_ready or vel < MIN_FLOOR:
+    return 0.0
+return min(vel * 1.10, self.feed_speed)
+```
+
+**Schlüssel-Änderungen vs Hotfix 6:**
+1. **HALL3:on → `max(vel*1.5, MIN_FLOOR)`** statt fix 30 mm/s. Cap auf `self.feed_speed` (30) als Obergrenze (Sicherheit).
+2. **`min(..., self.feed_speed)`** in beiden Zonen: Soft-Cap auf konfiguriertes Maximum (verhindert vel*1.5 > 30 bei sehr schnellen Drucken).
+3. **Initial-Boost-Pfad:** bei `vel_ready=False` (Print-Start, velocity_tracker noch sammelnd) UND HALL3:on → MIN_FLOOR=15.
+4. **Reihenfolge:** `hall_full`-Check vor velocity-Berechnung (Performance, defensive Coding).
+
+---
+
+## 5. Erwartete Hardware-Effekte
+
+**Bei Druck mit ~20 mm/s extruder_velocity (typisch):**
+- Vorher Hotfix 6: HALL3:on → 30 mm/s fix. 5mm @ 30 = 167ms Chunk, ~2.5mm Arm-Push pro Chunk. Bei 3 Chunks/sec wäre der Arm in ~3s an HALL1.
+- Mit Hotfix 7: HALL3:on → 20 * 1.5 = 30 mm/s, gleicher Effekt. Aber sobald Buffer in Zwischenzone (~67% der Zeit), springt target zu vel*1.1 = 22 mm/s und kein Schub-Stop mehr. Übergang HALL3 → Zwischenzone wird stetiger, weniger Speed-Hopping.
+
+**Bei Druck mit ~5 mm/s extruder_velocity (low-flow):**
+- Vorher: HALL3:on → 30 mm/s fix. Massiver Overshoot, 5mm Chunk = 6× extruder-Verbrauch. Buffer überfüllt sofort.
+- Mit Hotfix 7: HALL3:on → max(5 * 1.5, 15) = 15 mm/s. Schwung-Energie ~halbiert. Arm sollte vor HALL1 in HALL2-Bereich abbremsen.
+
+**Bei Druck-Start (vel_ready=False):**
+- Beide: 15 mm/s Initial. Buffer-Wiederbefüllung läuft eine kurze Anlauf-Phase, bis velocity_tracker primt.
+
+---
+
+## 6. Verbleibende Risiken
+
+1. **Wurzel 2/3 nicht vollständig adressiert:** Wenn HALL1-Storm in seltenen Edge-Cases doch noch auftritt (z.B. ruckartige Print-Pausen mit gefülltem Buffer), kann State-Drift weiterhin zur Stepcompress-Race führen. Defense-in-Depth-Patches (Hotfix 8+) bleiben für später möglich.
+2. **`velocity_tracker`-Tuning:** Wenn `velocity_tracker` mit zu langer Mittelungs-Zeit läuft, hinkt `vel` hinter realem Bedarf hinterher → Buffer könnte leerlaufen bei schnellen Print-Geschwindigkeits-Sprüngen. Aktueller Tracker-Code (in P7-78+ unverändert) ist hardware-validiert.
+3. **MIN_FLOOR = 15:** Bei sehr langsamem Print (3 mm/s, z.B. Linsen-Druck) übersteigt Soft-Throttle den Bedarf um 5× → Buffer könnte trotzdem überfüllen, aber langsamer als bei Hotfix 6 (15 statt 30 mm/s). Acceptable für ersten Hotfix7-Test.
+
+---
+
+## 7. Test-Strategie (für Phase 2-Plan)
+
+### TDD-Tests (RED-Schritt)
+- `test_hall_empty_with_vel_above_floor` — vel=20 → target=30 (capped auf feed_speed)
+- `test_hall_empty_with_vel_at_floor` — vel=15 → target=22.5
+- `test_hall_empty_with_vel_below_floor` — vel=8 → target=15 (MIN_FLOOR)
+- `test_hall_empty_with_vel_zero_ready` — vel=0, ready=True → target=15
+- `test_hall_empty_with_vel_not_ready` — ready=False → target=15
+- `test_intermediate_zone_with_vel` — vel=20, all halls off → target=22 (vel*1.10)
+- `test_intermediate_zone_low_vel` — vel=5, all halls off → target=0
+- `test_hall_full` — HALL2:on → target=0 (regression-check)
+- `test_hall_overflow` — HALL1:on → target=0 (regression-check)
+- `test_feed_speed_cap` — vel=50, feed_speed=30 → target=30 (Soft-Cap)
+
+### Hardware-Validierung (Phase 5)
+Print-Bett-Frage an User → Feedertest.gcode starten → Log beobachten:
+- **Erfolgs-Kriterium 1:** ≤2 HALL1-OVERFLOW-Zyklen über 4min Print (statt 16+)
+- **Erfolgs-Kriterium 2:** Kein `stepcompress c=N i=0 Invalid sequence` Crash
+- **Erfolgs-Kriterium 3:** `target_speed` in buffer_metrics korreliert sichtbar mit `tracker_vel` (statt 30/0-Hopping)
+
+---
+
+## 8. Commit-Message (Vorlage für Implementation-Phase)
+
+```
+C-cont Hotfix 7: Soft-Throttle — verbrauchskonforme Feeder-Geschwindigkeit
+
+Hardware-Crash 2026-05-13 (Feedertest.gcode, 4min 11sec):
+  stepcompress o=0 i=0 c=12 a=0: Invalid sequence
+  Error in syncemitter 'mellow' step generation
+  Exception in flush_handler → MCU-Shutdown
+
+Wurzel-Ursache (Hardware-Geometrie + Pipeline-Energie):
+  Buffer-Sensorik = optische Lichtschranken (NICHT Hall-Magnete)
+  HALL3↔HALL2 Abstand: 12.8mm
+  HALL2↔HALL1 Abstand:  3.6mm
+  Auslöser-Länge:      3-4mm
+  Hebel:               2:1 (5mm Filament-Push → 2.5mm Arm-Deflektion)
+  Hotfix6 5mm-Chunk @ 30 mm/s injiziert Schwung-Energie die den
+  Arm systematisch über HALL2 hinaus in HALL1 katapultiert
+  (3.6mm Sicherheitsmarge < 1 Sub-Chunk Auswirkung).
+
+Im klippy.log: 16+ HALL1-OVERFLOW-Zyklen in 80s vor Crash,
+HALL2 in buffer_metrics nie als "on" gesehen vor HALL1-Trigger
+(Polling-Aliasing wegen Schwung-Geschwindigkeit).
+
+Fix-Logik:
+  HALL3:on  → target = max(vel * 1.5, MIN_FLOOR)  # statt fix 30
+  HALL2:on  → target = 0                          # unverändert
+  HALL1:on  → OVERFLOW                            # unverändert
+  Zwischen  → target = vel * 1.10 (oder 0 bei vel<MIN_FLOOR)
+  cap:        target = min(target, feed_speed)
+
+Effekt: feed_speed skaliert mit Druck-Bedarf statt fixem
+Maximum. Bei langsamem Druck (vel=5 mm/s) schiebt Feeder nur
+15 mm/s statt 30 → Schwung-Energie halbiert → Arm bremst in
+HALL2-Sicherheitsfenster ab statt HALL1 zu treffen.
+
+Tests: 10 neue Test-Cases in test_speed_modulator.py
+       (vor: N → nach: N+10, alle grün)
+```
+
+---
+
+## 9. Offene Fragen / Pending-User-Decisions
+
+- [ ] User-Approval für Spec → Phase 2 (Plan)
+- [ ] Vorgehen Phase 4 (Code-Review): selbst-Review (kleine Änderung, <50 LOC) oder code-reviewer Subagent?
+- [ ] PR-Strategie nach Hardware-Test-Erfolg: in Fork commiten (Regel #9 zwingend) — separater PR zum Upstream nur nach User-Entscheidung

--- a/klipper_extras/buffer_feeder.py
+++ b/klipper_extras/buffer_feeder.py
@@ -2749,66 +2749,94 @@ class BufferFeeder:
             pass
 
     def _compute_target_feed_speed(self):
-        """C-cont T4 + Hotfix3/4/5/6: SpeedModulator.
+        """C-cont Hotfix7 (Hardware-Crash 2026-05-13 klippy.log
+        Z.104571, c=12 i=0 Invalid sequence nach 16+ HALL1-OVERFLOW-
+        Zyklen in 80s Druckzeit). Soft-Throttle: Feeder-Speed skaliert
+        mit Extruder-Verbrauch statt fixer Konstante.
 
-        Hotfix6: HALL3-Refill mit fester Konstante 30 mm/s (statt
-        self.feed_speed=70). Bei 70 mm/s schiesst der Arm in 130ms
-        durch HALL2 direkt in HALL1 (Hardware-Beleg klippy_real.log
-        2026-05-13: 6+ HALL3->HALL1-Cycles, dann c=16 crash). 30 mm/s
-        gibt 300ms Push-Zeit pro 5mm-Sub-Chunk -> HALL2 hat Zeit
-        zum Trigger, naechster Submit hat target=0 (Hotfix5 H2-stop).
+        Wurzel-Ursache (Hardware-Geometrie, User-vermessen 2026-05-13):
+          Sensorik:               optische Lichtschranken (KEINE Hall-
+                                  Magnete trotz Codename)
+          HALL3 <-> HALL2:        12.8 mm
+          HALL2 <-> HALL1:         3.6 mm  (Sicherheitsmarge)
+          Ausloeser-Fahne:         3-4 mm
+          Hebel:                  ~2:1 (5mm Filament-Push -> 2.5mm
+                                  Arm-Deflektion via Schlaufe)
+          Voller Hub HALL3->HALL1: 16.4 mm
 
-        Max-Throughput bei HALL3: 30 mm/s × 2.405 = 72 mm³/s. Reicht
-        fuer C-cont-Zielbereich (10-30 mm³/s Toolhead-Pull plus
-        Zwischenzone-Modulator 1.10× extruder_vel = bis ~33 mm/s).
+        Bei Hotfix6's fix 30 mm/s + 5mm Sub-Chunk dauert ein Sub-Chunk
+        ~167ms. HALL2->HALL1 Strecke (3.6mm) bei Schwung-Geschwindigkeit
+        ist in 120ms ueberbrueckt — kuerzer als ein Flush-Tick
+        (~250-500ms). Die Software ist strukturell zu langsam, um den
+        Arm vor HALL1 zu stoppen sobald er HALL2 erreicht. Im Log
+        (Z.104017-) sehen wir HALL1-Trigger OHNE vorheriges H2:on in
+        buffer_metrics — der Auslöser passiert HALL2 zwischen zwei
+        Polling-Ticks.
 
-        Hotfix5-Vorgeschichte gegen Overshoot-Cycle (Hardware-Beleg
-        klippy_real.log HEAD 2615b96):
-        - HALL2 active (Buffer voll) -> 0.0 (drain via Toolhead,
-          KEIN Push). Alter HALL2-Branch 0.5*v mit MIN_FLOOR=15
-          verursachte Submit @15 mm/s in vollen Buffer wenn
-          tracker_vel=1.6 (Resume-Phase). Strukturell falsch — bei
-          vollem Buffer NIE foerdern.
-        - HALL3 active (Buffer leer) -> feed_speed (lll=70) statt
-          max_feed_speed (100). HALL3-Submit @100 mm/s ueberschoss
-          Arm in 1 Sub-Chunk von HALL3 nach HALL1. Hotfix6: jetzt
-          30 mm/s konstant — feed_speed=70 war immer noch zu schnell.
-        - Zwischenzone proposed < MIN_FLOOR -> 0 (Pipeline-Safe
-          Skip statt force-clamp). Bei tracker=10 -> 1.10*10=11 <
-          15 wurde vorher auf 15 geclampt -> Pipeline-Last bei
-          niedrigem Flow. Stattdessen kein Submit bis tracker_vel
-          hoch genug fuer Pipeline-Safety.
+        Hotfix7 koppelt feed_speed an Extruder-Verbrauch -> bei
+        langsamem Druck (vel=5) schiebt Feeder nur 15 mm/s statt 30
+        -> halbierte Schwung-Energie -> Arm bremst in HALL2-
+        Sicherheitsfenster ab.
 
         Logik:
-          HALL1 (overflow)        -> 0.0 (Notbremse)
-          HALL2 (full)            -> 0.0 (Hotfix5: kein Push in
-                                          vollen Buffer)
-          HALL3 (empty)           -> 30.0 (Hotfix6: feste sanfte
-                                            Refill-Speed)
-          tracker not_ready       -> 0.0 (Boot: warten)
-          tracker vel <= 0        -> 0.0 (Toolhead stalled)
-          Zwischenzone proposed
-            < MIN_FLOOR           -> 0.0 (Hotfix5: lieber kein
-                                          Submit als zu langsam)
-            >= MIN_FLOOR          -> extruder_vel * 1.10
+          HALL1 (overflow)            -> 0.0 (Notbremse)
+          HALL2 (full)                -> 0.0 (Hotfix5: kein Push in
+                                              vollen Buffer)
+          HALL3 (empty):
+            tracker not_ready         -> MIN_FLOOR=15 (Print-Start sanft)
+            vel < MIN_FLOOR oder vel=0 -> MIN_FLOOR=15 (Initial/Idle)
+            vel >= MIN_FLOOR          -> min(vel*1.5, feed_speed)
+                                          (50% Margin ueber Verbrauch,
+                                           cap auf konfiguriertes Max)
+          Zwischenzone (kein HALL):
+            tracker not_ready         -> 0.0 (Boot warten)
+            vel < MIN_FLOOR oder vel=0 -> 0.0 (Hotfix5: lieber kein
+                                              Submit als zu langsam)
+            vel >= MIN_FLOOR          -> min(vel*1.10, feed_speed)
+                                          (10% Margin, cap auf Max)
+
+        Hotfix6 (vorher): HALL3:on -> 30 mm/s fix. Bei vel=5 (low-flow
+        Druck) injiziert das 6x Verbrauch -> Buffer-Arm-Overshoot
+        HALL2->HALL1 regelmaessig (siehe Hardware-Beleg oben).
+
+        Soft-Cap auf feed_speed (NEU vs Hotfix3): verhindert dass
+        vel*1.5 oder vel*1.10 bei schnellen Drucken target_speed
+        ueber die konfigurierte Obergrenze treibt. Hardware-sicher
+        weil feed_speed im cfg bereits hardware-validiert ist.
+
+        Siehe specs/2026-05-13-c-cont-hotfix7-soft-throttle.md fuer
+        vollstaendige Analyse und Optionen-Vergleich (A/B/C).
         """
+        MIN_FLOOR = 15.0  # mm/s, ererbt von Hotfix3 (validated baseline)
+        # Boundary-tolerant comparison gegen MIN_FLOOR: vel_tracker
+        # akkumuliert FP-Drift via 0.025s-Ticks (0.025 ist nicht exakt
+        # in binary representable). Ohne Epsilon faellt vel=MIN_FLOOR
+        # genau auf den falschen Pfad. 1e-6 mm/s Toleranz ist hardware-
+        # irrelevant (kleiner als jeder Stepper-Microstep).
+        FLOOR_EPSILON = 1e-6
+
         if self.hall_overflow:
             return 0.0
         if self.hall_full:
             return 0.0  # Hotfix5: HALL2 = stop (Buffer voll)
+
+        vel_ready = self.velocity_tracker.is_ready()
+        extruder_vel = self.velocity_tracker.get_velocity() if vel_ready \
+            else 0.0
+
         if self.hall_empty:
-            return 30.0  # Hotfix6: feste sanfte Refill-Speed
-        # Zwischenzone — fluss-proportional, aber kein Force-Clamp
-        if not self.velocity_tracker.is_ready():
-            return 0.0  # Boot: kein Submit, warten auf Tracker
-        extruder_vel = self.velocity_tracker.get_velocity()
-        if extruder_vel <= 0.0:
-            return 0.0  # Toolhead stalled — nicht foerdern
-        MIN_FLOOR = 15.0  # mm/s — Pipeline-Backpressure-Mindest
-        proposed = extruder_vel * 1.10
-        if proposed < MIN_FLOOR:
-            return 0.0  # Hotfix5: lieber kein Submit als zu langsam
-        return proposed
+            # HALL3:on -> Buffer leer, Auffuellen mit 50% Margin ueber
+            # Verbrauch. Bei not_ready / vel<MIN_FLOOR: MIN_FLOOR-Boden
+            # damit Buffer trotzdem gefuellt wird, aber sanft (statt
+            # Hotfix6 30 mm/s).
+            if not vel_ready or extruder_vel < MIN_FLOOR - FLOOR_EPSILON:
+                return MIN_FLOOR
+            return min(max(extruder_vel * 1.5, MIN_FLOOR), self.feed_speed)
+
+        # Zwischenzone (kein HALL aktiv)
+        if not vel_ready or extruder_vel < MIN_FLOOR - FLOOR_EPSILON:
+            return 0.0  # Hotfix5 unveraendert
+        return min(extruder_vel * 1.10, self.feed_speed)
 
     def _on_mcu_flush(self, flush_time, step_gen_time):
         """P7-52: Flush-callback driven bang-bang. Klipper's motion_

--- a/tests/test_c_cont_streaming.py
+++ b/tests/test_c_cont_streaming.py
@@ -152,18 +152,17 @@ def test_c_cont_modulator_hall1_zero(monkeypatch):
 
 
 def test_c_cont_modulator_hall3_max(monkeypatch):
-    """Hotfix6: HALL3 active (Buffer leer) -> 30.0 mm/s konstant
-    (sanfter Initial-Fill). Hotfix5 nutzte feed_speed=70, was
-    HALL3->HALL1 ueberschoss (Hardware-Beleg klippy_real.log
-    2026-05-13: 6+ Cycles HALL3->HALL1, c=16 crash). Hotfix6:
-    30 mm/s gibt 300ms Push-Zeit pro 5mm Sub-Chunk -> HALL2 hat
-    Zeit zum Trigger."""
+    """Hotfix7-Update: HALL3:on + vel=15 -> max(15*1.5=22.5, 15)=22.5.
+    Hotfix6 nutzte fix 30 mm/s; Hardware-Crash 2026-05-13 (klippy.log
+    Z.104571, c=12 i=0) zeigte dass fixer 30 mm/s Schub bei
+    HALL2<->HALL1 nur 3.6mm Sicherheitsmarge regelmaessig in HALL1
+    overshoot. Hotfix7 koppelt Speed an Extruder-Verbrauch."""
     printer, feeder = make_c_cont_feeder(monkeypatch)
     set_sensor_active(feeder, 'hall_empty', True)
     set_sensor_active(feeder, 'hall_full', False)
     set_sensor_active(feeder, 'hall_overflow', False)
     _populate_tracker_to_ready(feeder, velocity=15.0)
-    assert feeder._compute_target_feed_speed() == 30.0
+    assert feeder._compute_target_feed_speed() == pytest.approx(22.5, abs=0.1)
 
 
 def test_c_cont_modulator_hall2_half(monkeypatch):
@@ -255,10 +254,10 @@ def test_c_cont_hotfix4_stalled_toolhead_no_submit_in_full_buffer(monkeypatch):
 
 
 def test_c_cont_hotfix4_stalled_but_hall_empty_still_fills(monkeypatch):
-    """Hotfix6: HALL3 active + Toolhead stalled -> foerdere TROTZDEM
-    (Buffer wirklich leer). Hotfix6-Update: 30.0 mm/s konstant statt
-    feed_speed (sanfter Initial-Fill, vermeidet HALL3->HALL1
-    Durchschuss)."""
+    """Hotfix7-Update: HALL3 active + Toolhead stalled (vel=0) ->
+    foerdere TROTZDEM (Buffer wirklich leer), aber sanft mit
+    MIN_FLOOR=15 statt Hotfix6's fix 30.0 (Hardware-Crash
+    2026-05-13, klippy.log Z.104571: 16+ HALL1-Cycles, c=12 i=0)."""
     printer, feeder = make_c_cont_feeder(monkeypatch)
     set_sensor_active(feeder, 'hall_empty', True)
     set_sensor_active(feeder, 'hall_full', False)
@@ -270,8 +269,8 @@ def test_c_cont_hotfix4_stalled_but_hall_empty_still_fills(monkeypatch):
         feeder.velocity_tracker.tick(t)
         t += 0.025
     assert feeder.velocity_tracker.get_velocity() == 0.0
-    # HALL3 dominiert -> 30.0 (vor not_ready/stalled-Checks)
-    assert feeder._compute_target_feed_speed() == 30.0
+    # Hotfix7: HALL3 + vel=0 -> MIN_FLOOR=15 (statt Hotfix6 30.0)
+    assert feeder._compute_target_feed_speed() == pytest.approx(15.0, abs=0.1)
 
 
 def test_c_cont_hotfix4_not_ready_no_submit_in_full(monkeypatch):
@@ -286,14 +285,16 @@ def test_c_cont_hotfix4_not_ready_no_submit_in_full(monkeypatch):
 
 
 def test_c_cont_hotfix4_not_ready_but_hall_empty_uses_fallback(monkeypatch):
-    """Hotfix6: tracker not_ready + HALL3 -> 30.0 mm/s (sanfter
-    Initial-Fill, Hotfix6-Konstante statt feed_speed)."""
+    """Hotfix7-Update: tracker not_ready + HALL3 -> MIN_FLOOR=15 mm/s
+    (Print-Start sanft). Hotfix6 nutzte fix 30 mm/s -> aggressiver
+    Initial-Fill schoss in HALL1 over (Hardware-Beleg klippy.log
+    Z.104571, c=12 i=0)."""
     printer, feeder = make_c_cont_feeder(monkeypatch)
     set_sensor_active(feeder, 'hall_empty', True)
     set_sensor_active(feeder, 'hall_full', False)
     set_sensor_active(feeder, 'hall_overflow', False)
     assert not feeder.velocity_tracker.is_ready()
-    assert feeder._compute_target_feed_speed() == 30.0
+    assert feeder._compute_target_feed_speed() == pytest.approx(15.0, abs=0.1)
 
 
 # ---------------------------------------------------------------------------
@@ -317,15 +318,18 @@ def test_c_cont_hotfix3_zwischen_soft_floor_low_vel(monkeypatch):
 
 
 def test_c_cont_hotfix3_zwischen_soft_floor_high_vel(monkeypatch):
-    """Hotfix3: Zwischenzone bei high velocity = 1.10 * vel.
-    High velocity (50 mm/s): erwarte 1.10 * 50 = 55."""
+    """Hotfix7-Update: Zwischenzone bei high velocity = min(1.10*vel,
+    feed_speed). vel=50 -> 1.10*50=55, capped auf feed_speed=30.
+    Vorher Hotfix3: unbounded 55. NEUER Soft-Cap verhindert dass
+    target_speed > konfigurierte Obergrenze waechst (Hardware-
+    Sicherheit, Hotfix7)."""
     printer, feeder = make_c_cont_feeder(monkeypatch)
     set_sensor_active(feeder, 'hall_empty', False)
     set_sensor_active(feeder, 'hall_full', False)
     set_sensor_active(feeder, 'hall_overflow', False)
     _populate_tracker_to_ready(feeder, velocity=50.0)
-    # max(15, 1.10*50=55) -> 55
-    assert feeder._compute_target_feed_speed() == pytest.approx(55.0, abs=1.0)
+    # min(1.10*50=55, feed_speed=30) -> 30
+    assert feeder._compute_target_feed_speed() == pytest.approx(30.0, abs=0.1)
 
 
 def test_c_cont_hotfix3_hall2_soft_floor_low_vel(monkeypatch):
@@ -373,19 +377,27 @@ def test_c_cont_hotfix5_hall2_returns_zero(monkeypatch):
     assert feeder._compute_target_feed_speed() == 0.0
 
 
-def test_c_cont_hotfix6_hall3_uses_30_not_feed_speed(monkeypatch):
-    """Hotfix6: HALL3 nutzt feste 30.0 mm/s (statt feed_speed=70).
-    Hotfix5 nutzte feed_speed; das war immer noch zu schnell und
-    schoss in 130ms HALL3->HALL1 durch (Hardware-Beleg
-    klippy_real.log 2026-05-13)."""
+def test_c_cont_hotfix7_hall3_scales_with_vel_under_high_feed_speed(monkeypatch):
+    """Hotfix7 (ersetzt Hotfix6): HALL3 + vel=20, feed_speed=70 ->
+    max(20*1.5=30, 15)=30, capped auf feed_speed=70 -> 30.
+    Hotfix7 koppelt Speed an Verbrauch statt fixer Konstante.
+    Hardware-Crash 2026-05-13 (klippy.log Z.104571, c=12 i=0) zeigte
+    dass Hotfix6's fixer 30 mm/s bei niedrigem vel (5-10) immer noch
+    HALL2->HALL1 ueberschoss (3.6mm Sicherheitsmarge)."""
     printer, feeder = make_c_cont_feeder(
         monkeypatch, cfg_overrides={'feed_speed': 70.0})
     set_sensor_active(feeder, 'hall_empty', True)
     set_sensor_active(feeder, 'hall_full', False)
     set_sensor_active(feeder, 'hall_overflow', False)
-    assert feeder._compute_target_feed_speed() == 30.0
-    assert feeder._compute_target_feed_speed() != feeder.feed_speed
-    assert feeder._compute_target_feed_speed() != feeder.max_feed_speed
+    _populate_tracker_to_ready(feeder, velocity=20.0)
+    # 20*1.5=30, capped auf feed_speed=70 -> 30
+    assert feeder._compute_target_feed_speed() == pytest.approx(30.0, abs=0.1)
+    # Bei hoeherem vel: vel*1.5 bis feed_speed-Cap. Tracker resetten,
+    # damit alte Samples die neue Velocity nicht verfaelschen.
+    feeder.velocity_tracker.reset()
+    _populate_tracker_to_ready(feeder, velocity=60.0)
+    # 60*1.5=90 -> capped auf feed_speed=70
+    assert feeder._compute_target_feed_speed() == pytest.approx(70.0, abs=0.1)
 
 
 def test_c_cont_hotfix5_zwischen_below_min_floor_skips(monkeypatch):
@@ -410,6 +422,194 @@ def test_c_cont_hotfix5_zwischen_above_min_floor_proportional(monkeypatch):
     set_sensor_active(feeder, 'hall_overflow', False)
     _populate_tracker_to_ready(feeder, velocity=20.0)
     assert feeder._compute_target_feed_speed() == pytest.approx(22.0, abs=1.0)
+
+
+# ---------------------------------------------------------------------------
+# C-cont Hotfix 7 (Hardware-Crash 2026-05-13 klippy.log Z.104571, c=12 i=0
+# Invalid sequence nach 16+ HALL1-OVERFLOW-Zyklen in 80s).
+# Soft-Throttle: Feeder-Speed skaliert mit Extruder-Verbrauch statt fix
+# 30 mm/s. Adressiert Hardware-Geometrie (optische Lichtschranken,
+# HALL3<->HALL2=12.8mm, HALL2<->HALL1=3.6mm, Ausloeser 3-4mm, Hebel 2:1)
+# vs Hotfix6's 5mm-Chunk-Schwung-Energie.
+# Siehe specs/2026-05-13-c-cont-hotfix7-soft-throttle.md
+# ---------------------------------------------------------------------------
+
+
+def test_c_cont_hotfix7_hall3_high_vel_capped_at_feed_speed(monkeypatch):
+    """Hotfix7: HALL3:on + vel=25 -> max(25*1.5=37.5, 15) capped auf
+    feed_speed=30. Soft-Cap verhindert ueberzogene Speeds bei schnellen
+    Drucken."""
+    printer, feeder = make_c_cont_feeder(monkeypatch)
+    set_sensor_active(feeder, 'hall_empty', True)
+    set_sensor_active(feeder, 'hall_full', False)
+    set_sensor_active(feeder, 'hall_overflow', False)
+    _populate_tracker_to_ready(feeder, velocity=25.0)
+    # 25*1.5=37.5 > feed_speed=30 -> capped to 30
+    assert feeder._compute_target_feed_speed() == pytest.approx(30.0, abs=0.1)
+
+
+def test_c_cont_hotfix7_hall3_mid_vel_scales_with_extruder(monkeypatch):
+    """Hotfix7: HALL3:on + vel=15 -> max(15*1.5=22.5, 15)=22.5.
+    Scaling mit Verbrauch statt fixe 30 mm/s -> halbierte Schwung-Energie
+    bei moderaten Drucken."""
+    printer, feeder = make_c_cont_feeder(monkeypatch)
+    set_sensor_active(feeder, 'hall_empty', True)
+    set_sensor_active(feeder, 'hall_full', False)
+    set_sensor_active(feeder, 'hall_overflow', False)
+    _populate_tracker_to_ready(feeder, velocity=15.0)
+    assert feeder._compute_target_feed_speed() == pytest.approx(22.5, abs=0.1)
+
+
+def test_c_cont_hotfix7_hall3_low_vel_uses_min_floor(monkeypatch):
+    """Hotfix7: HALL3:on + vel=8 (unter MIN_FLOOR) -> 15 mm/s
+    (MIN_FLOOR-Boden). 8*1.5=12 < 15 -> Floor wins."""
+    printer, feeder = make_c_cont_feeder(monkeypatch)
+    set_sensor_active(feeder, 'hall_empty', True)
+    set_sensor_active(feeder, 'hall_full', False)
+    set_sensor_active(feeder, 'hall_overflow', False)
+    _populate_tracker_to_ready(feeder, velocity=8.0)
+    assert feeder._compute_target_feed_speed() == pytest.approx(15.0, abs=0.1)
+
+
+def test_c_cont_hotfix7_hall3_vel_zero_uses_min_floor(monkeypatch):
+    """Hotfix7: HALL3:on + tracker ready aber vel=0 (Toolhead stalled
+    mit leerem Buffer) -> 15 mm/s. Buffer muss trotz Stall gefuellt
+    werden, aber sanft (MIN_FLOOR statt 30)."""
+    printer, feeder = make_c_cont_feeder(monkeypatch)
+    set_sensor_active(feeder, 'hall_empty', True)
+    set_sensor_active(feeder, 'hall_full', False)
+    set_sensor_active(feeder, 'hall_overflow', False)
+    # Tracker ready aber vel=0
+    fake_ext = feeder.printer.objects['extruder']
+    t = 0.0
+    for _ in range(12):
+        fake_ext.last_position = 100.0  # konstant -> vel=0
+        feeder.velocity_tracker.tick(t)
+        t += 0.025
+    assert feeder.velocity_tracker.is_ready()
+    assert feeder.velocity_tracker.get_velocity() == 0.0
+    assert feeder._compute_target_feed_speed() == pytest.approx(15.0, abs=0.1)
+
+
+def test_c_cont_hotfix7_hall3_tracker_not_ready_uses_min_floor(monkeypatch):
+    """Hotfix7: HALL3:on + tracker noch nicht ready (Print-Start) ->
+    15 mm/s. Vorher Hotfix6: 30 mm/s -> aggressiver Initial-Fill ->
+    HALL1-Overshoot waehrend velocity_tracker noch sammelt."""
+    printer, feeder = make_c_cont_feeder(monkeypatch)
+    set_sensor_active(feeder, 'hall_empty', True)
+    set_sensor_active(feeder, 'hall_full', False)
+    set_sensor_active(feeder, 'hall_overflow', False)
+    assert not feeder.velocity_tracker.is_ready()
+    assert feeder._compute_target_feed_speed() == pytest.approx(15.0, abs=0.1)
+
+
+def test_c_cont_hotfix7_zwischen_low_vel_zero(monkeypatch):
+    """Hotfix7: Zwischenzone + vel<MIN_FLOOR -> 0.0 (unveraendert
+    von Hotfix5: vermeidet Submits bei Spurious-Buffer-Drift)."""
+    printer, feeder = make_c_cont_feeder(monkeypatch)
+    set_sensor_active(feeder, 'hall_empty', False)
+    set_sensor_active(feeder, 'hall_full', False)
+    set_sensor_active(feeder, 'hall_overflow', False)
+    _populate_tracker_to_ready(feeder, velocity=5.0)
+    assert feeder._compute_target_feed_speed() == 0.0
+
+
+def test_c_cont_hotfix7_zwischen_high_vel_capped(monkeypatch):
+    """Hotfix7: Zwischenzone + vel=40 -> min(40*1.10=44, feed_speed=30)=30.
+    NEUER Soft-Cap in Zwischenzone (vorher: unbounded vel*1.10).
+    Verhindert dass schnelle Drucke target_speed > feed_speed setzen."""
+    printer, feeder = make_c_cont_feeder(monkeypatch)
+    set_sensor_active(feeder, 'hall_empty', False)
+    set_sensor_active(feeder, 'hall_full', False)
+    set_sensor_active(feeder, 'hall_overflow', False)
+    _populate_tracker_to_ready(feeder, velocity=40.0)
+    assert feeder._compute_target_feed_speed() == pytest.approx(30.0, abs=0.1)
+
+
+def test_c_cont_hotfix7_zwischen_tracker_not_ready_zero(monkeypatch):
+    """Hotfix7: Zwischenzone + tracker not_ready -> 0.0 (unveraendert
+    von Hotfix4: nur HALL3:on darf bei not_ready foerdern, alle anderen
+    Zonen warten auf echte Velocity)."""
+    printer, feeder = make_c_cont_feeder(monkeypatch)
+    set_sensor_active(feeder, 'hall_empty', False)
+    set_sensor_active(feeder, 'hall_full', False)
+    set_sensor_active(feeder, 'hall_overflow', False)
+    assert not feeder.velocity_tracker.is_ready()
+    assert feeder._compute_target_feed_speed() == 0.0
+
+
+def test_c_cont_hotfix7_hall2_zero_regression(monkeypatch):
+    """Regression: HALL2:on -> 0.0 (unveraendert von Hotfix5).
+    Stellt sicher dass Hotfix7-Umbau den HALL2-Pfad nicht bricht."""
+    printer, feeder = make_c_cont_feeder(monkeypatch)
+    set_sensor_active(feeder, 'hall_empty', False)
+    set_sensor_active(feeder, 'hall_full', True)
+    set_sensor_active(feeder, 'hall_overflow', False)
+    _populate_tracker_to_ready(feeder, velocity=20.0)
+    assert feeder._compute_target_feed_speed() == 0.0
+
+
+def test_c_cont_hotfix7_hall1_zero_regression(monkeypatch):
+    """Regression: HALL1:on -> 0.0 (Notbremse). Stellt sicher dass
+    Hotfix7-Umbau den OVERFLOW-Pfad nicht beeinflusst."""
+    printer, feeder = make_c_cont_feeder(monkeypatch)
+    set_sensor_active(feeder, 'hall_overflow', True)
+    set_sensor_active(feeder, 'hall_empty', False)
+    set_sensor_active(feeder, 'hall_full', False)
+    _populate_tracker_to_ready(feeder, velocity=20.0)
+    assert feeder._compute_target_feed_speed() == 0.0
+
+
+def test_c_cont_hotfix7_tracker_lag_documents_tradeoff(monkeypatch):
+    """Hotfix7 Lag-Verhalten (Reviewer-Concern I2): Auf Hardware kann
+    der velocity_tracker nicht zwischen Flushes resettet werden.
+    Sliding-Window mittelt ueber 300ms. Wenn der Extruder seine
+    Geschwindigkeit rapide drosselt (z.B. Ende eines G1-Segments),
+    lagt der Tracker um genau das Sliding-Window.
+
+    Dieser Test dokumentiert das Trade-Off explizit: nach 5 Samples
+    bei vel=5 (~125ms) hat der Tracker noch 7 alte Samples bei
+    vel=30 -> Mittelwert ~24 mm/s -> target_speed entsprechend hoch.
+    Spec §6.2 akzeptiert das, aber dieser Test verhindert dass
+    zukuenftige Optimierungen das Lag-Verhalten unbemerkt aendern."""
+    printer, feeder = make_c_cont_feeder(monkeypatch)
+    set_sensor_active(feeder, 'hall_empty', True)
+    set_sensor_active(feeder, 'hall_full', False)
+    set_sensor_active(feeder, 'hall_overflow', False)
+
+    fake_ext = feeder.printer.objects['extruder']
+    # Phase 1: 12 Samples bei vel=30, Tracker primed auf 30
+    pos = 0.0
+    t = 0.0
+    for _ in range(12):
+        fake_ext.last_position = pos
+        feeder.velocity_tracker.tick(t)
+        pos += 30.0 * 0.025  # vel=30
+        t += 0.025
+    assert feeder.velocity_tracker.is_ready()
+    assert feeder.velocity_tracker.get_velocity() == pytest.approx(30.0, abs=0.5)
+    # Phase 2: 5 weitere Samples bei vel=5 (Extruder drosselt rapide).
+    # KEIN reset() — hardware-realistisches Lag-Verhalten.
+    for _ in range(5):
+        fake_ext.last_position = pos
+        feeder.velocity_tracker.tick(t)
+        pos += 5.0 * 0.025  # vel=5
+        t += 0.025
+    # Tracker mittelt jetzt ueber 7 alte (vel=30) + 5 neue (vel=5) Samples.
+    # Erwartete Mittel-Velocity zwischen ~15 und ~25 (haengt vom genauen
+    # Window-Verhalten ab). Wichtig: Target ist NICHT auf MIN_FLOOR
+    # gefallen — Soft-Throttle lagt mit dem Tracker.
+    lagged_vel = feeder.velocity_tracker.get_velocity()
+    assert lagged_vel > 10.0, (
+        "Tracker-Lag dokumentiert: nach 5 Drossel-Samples sollte vel "
+        "noch deutlich ueber 5 mm/s sein (alte Samples ueberwiegen). "
+        f"Tatsaechlich: {lagged_vel:.2f}")
+    # Target_speed: HALL3 + lagged_vel -> max(lagged_vel*1.5, MIN_FLOOR)
+    target = feeder._compute_target_feed_speed()
+    expected_target = min(max(lagged_vel * 1.5, 15.0), feeder.feed_speed)
+    assert target == pytest.approx(expected_target, abs=0.1), (
+        f"Target {target} muss aktuellem (gelaggten) tracker_vel "
+        f"folgen: erwartet {expected_target}")
 
 
 # ===========================================================================
@@ -525,9 +725,10 @@ def _capture_submits(feeder, monkeypatch):
 def test_c_cont_continuous_streaming_in_auto(monkeypatch):
     """STATE_AUTO + HALL3 stable + tracker ready -> Submit bei jedem flush.
 
-    Hotfix6: HALL3-Submit nutzt feste 30.0 mm/s (statt feed_speed=70
-    in Hotfix5) — sanfter Initial-Fill verhindert HALL3->HALL1
-    Durchschuss in 130ms."""
+    Hotfix7-Update: HALL3-Submit nutzt max(vel*1.5, MIN_FLOOR) capped
+    auf feed_speed. vel=15 -> 15*1.5=22.5 -> Submit-Speed 22.5.
+    Vorher Hotfix6: fix 30.0 (Hardware-Crash 2026-05-13 zeigte dass
+    fixer 30 trotzdem HALL2->HALL1 overshoot)."""
     printer, feeder = make_c_cont_feeder(monkeypatch)
     feeder._state = buffer_feeder.STATE_AUTO
     set_sensor_active(feeder, 'hall_empty', True)
@@ -538,21 +739,22 @@ def test_c_cont_continuous_streaming_in_auto(monkeypatch):
     feeder._pending_remaining_mm = 0.0
     feeder._on_mcu_flush(flush_time=10.0, step_gen_time=10.0)
     assert len(submits) == 1
-    assert submits[0]['speed'] == 30.0
+    # Hotfix7: 15*1.5=22.5 (statt Hotfix6 fix 30.0)
+    assert submits[0]['speed'] == pytest.approx(22.5, abs=0.1)
 
 
 def test_c_cont_speed_modulation_via_hall_state(monkeypatch):
     """HALL-State-Change zwischen flushes -> Speed-Aenderung.
 
-    Hotfix6:
-    - HALL3 -> 30.0 mm/s (sanfter Initial-Fill, Hotfix6-Konstante)
+    Hotfix7-Update:
+    - HALL3 + vel=40 -> min(40*1.5=60, feed_speed=30)=30 (capped)
     - HALL2 -> 0.0 (kein Submit, Buffer voll = drain ueber Toolhead)
     """
     printer, feeder = make_c_cont_feeder(monkeypatch)
     feeder._state = buffer_feeder.STATE_AUTO
     _populate_tracker_to_ready(feeder, velocity=40.0)
     submits = _capture_submits(feeder, monkeypatch)
-    # HALL3 -> 30.0
+    # HALL3 -> 30 (40*1.5=60 capped auf feed_speed=30)
     set_sensor_active(feeder, 'hall_empty', True)
     feeder._last_move_end_time = 0.0
     feeder._pending_remaining_mm = 0.0
@@ -564,7 +766,8 @@ def test_c_cont_speed_modulation_via_hall_state(monkeypatch):
     feeder._on_mcu_flush(flush_time=10.5, step_gen_time=10.5)
     # Nur 1 Submit (HALL3), HALL2 ist Skip
     assert len(submits) == 1
-    assert submits[0]['speed'] == 30.0
+    # Hotfix7: 40*1.5=60 capped auf feed_speed=30
+    assert submits[0]['speed'] == pytest.approx(30.0, abs=0.1)
 
 
 def test_c_cont_hall1_active_no_submit(monkeypatch):
@@ -643,8 +846,9 @@ def test_c_cont_pending_chunk_uses_current_target_speed(monkeypatch):
     """_tick_pending_chunk submittet Sub-Chunks mit aktuellem target_speed,
     nicht eingefrorenem Speed vom ersten Submit.
 
-    Hotfix3: Zwischenzone-Output = max(15, vel*1.10). Bei velocity=30
-    ist 1.10*30=33 > MIN_FLOOR=15, also expect 33.
+    Hotfix7-Update: Zwischenzone-Output = min(vel*1.10, feed_speed).
+    Bei velocity=30: 1.10*30=33 > feed_speed=30 -> capped auf 30.
+    Vorher Hotfix3: unbounded 33 (kein Soft-Cap).
     Im Continuous-Mode submittet _on_mcu_flush nur noch interrupt_-
     chunk_mm (9), kein _pending_remaining_mm. Wir setzen Pending hier
     kuenstlich um _tick_pending_chunk-Logik zu testen.
@@ -661,12 +865,12 @@ def test_c_cont_pending_chunk_uses_current_target_speed(monkeypatch):
     feeder._last_move_end_time = 10.0
     # HALL-Wechsel von HALL3 -> Zwischenzone (buffer fuellt sich):
     set_sensor_active(feeder, 'hall_empty', False)
-    # Zwischenzone Hotfix3: max(15, 1.10*30=33) = 33
-    assert feeder._compute_target_feed_speed() == pytest.approx(33.0, abs=1.0)
+    # Hotfix7: min(1.10*30=33, feed_speed=30) = 30 (NEUER Soft-Cap)
+    assert feeder._compute_target_feed_speed() == pytest.approx(30.0, abs=0.1)
     trapezoids = _capture_trapezoids(feeder, monkeypatch)
     feeder._tick_pending_chunk(eventtime=10.0)
     assert len(trapezoids) == 1
-    assert trapezoids[0]['speed'] == pytest.approx(33.0, abs=1.0)
+    assert trapezoids[0]['speed'] == pytest.approx(30.0, abs=0.1)
     assert trapezoids[0]['speed'] != feeder.max_feed_speed
 
 
@@ -791,14 +995,18 @@ def test_c_cont_continuous_feed_persists_through_hall_state_change(monkeypatch):
     sich der HALL-State zwischen Submits aendert (Speed wird nur
     moduliert, kein Stream-Reset).
 
-    Hotfix3: Zwischenzone-Output = max(15, vel*1.10). Bei velocity=40
-    ist 1.10*40=44 > MIN_FLOOR=15, also expect 44.
-    """
-    printer, feeder = make_c_cont_feeder(monkeypatch)
+    Hotfix7-Update: HALL3 + vel=40 -> min(40*1.5=60, feed_speed)
+    (Soft-Cap). Zwischenzone + vel=40 -> min(1.10*40=44, feed_speed)
+    (Soft-Cap). Wenn feed_speed niedrig ist (z.B. 30), cappen BEIDE
+    Submits auf feed_speed -> Modulation nicht mehr beobachtbar.
+    Daher feed_speed=70 nutzen: HALL3=60, Zwischenzone=44 -> beide
+    unterschiedlich, Modulations-Invariante erhalten."""
+    printer, feeder = make_c_cont_feeder(
+        monkeypatch, cfg_overrides={'feed_speed': 70.0})
     feeder._state = buffer_feeder.STATE_AUTO
     _populate_tracker_to_ready(feeder, velocity=40.0)
     submits = _capture_submits(feeder, monkeypatch)
-    # HALL3 -> max_feed_speed, erster Submit setzt _continuous_feed=True
+    # HALL3 -> Hotfix7: 40*1.5=60 (unter feed_speed=70, kein Cap)
     set_sensor_active(feeder, 'hall_empty', True)
     feeder._last_move_end_time = 0.0
     feeder._pending_remaining_mm = 0.0
@@ -807,16 +1015,21 @@ def test_c_cont_continuous_feed_persists_through_hall_state_change(monkeypatch):
     assert feeder._continuous_feed is True
     assert len(submits) == 1
     first_submit_speed = submits[0]['speed']
+    assert first_submit_speed == pytest.approx(60.0, abs=0.1)
     # HALL-State-Change: HALL3 -> Zwischenzone (alle HALL inactive).
     set_sensor_active(feeder, 'hall_empty', False)
     feeder._last_move_end_time = 0.0  # vorheriger Move done
     feeder._on_mcu_flush(flush_time=10.5, step_gen_time=10.5)
-    # _continuous_feed bleibt strukturell True:
+    # _continuous_feed bleibt strukturell True (kein Stream-Reset bei
+    # HALL-Wechsel):
     assert feeder._continuous_feed is True
-    # Speed wurde moduliert (Zwischenzone Hotfix3 = max(15, 1.10*40)=44):
+    # Zweiter Submit: Zwischenzone Hotfix7 = min(1.10*40=44, feed_speed=70)
+    # = 44 (unter Cap):
     assert len(submits) == 2
-    assert submits[1]['speed'] == pytest.approx(44.0, abs=1.0)
-    # Speed-Aenderung gegenueber erstem Submit ist erfolgt (Modulation):
+    assert submits[1]['speed'] == pytest.approx(44.0, abs=0.1)
+    # Modulations-Invariante (Reviewer I1): Speed hat sich strukturell
+    # geaendert zwischen den Submits — beweist dass HALL-State-Change
+    # die Modulation triggert (nicht nur ein zufaelliger zweiter Submit).
     assert submits[1]['speed'] != first_submit_speed
 
 
@@ -834,9 +1047,9 @@ def test_c_cont_hotfix3_pipeline_one_chunk_only(monkeypatch):
     die Pipeline sofort beim naechsten flush-callback (Hardware
     2026-05-13 klippy(9), 30/30 Cycles HALL1-Overshoot-Storm fix).
 
-    Hotfix6: HALL3-Speed ist jetzt 30.0 mm/s konstant (statt
-    feed_speed=70 in Hotfix5) + interrupt_chunk_mm default 5mm
-    (statt 9mm in Hotfix5)."""
+    Hotfix7-Update: HALL3-Speed = min(max(vel*1.5, MIN_FLOOR),
+    feed_speed). Bei vel=15: 15*1.5=22.5 -> Submit-Speed=22.5.
+    Pipeline-Cap (interrupt_chunk_mm=5) unveraendert von Hotfix6."""
     printer, feeder = make_c_cont_feeder(monkeypatch)
     feeder._state = buffer_feeder.STATE_AUTO
     set_sensor_active(feeder, 'hall_empty', True)
@@ -846,13 +1059,12 @@ def test_c_cont_hotfix3_pipeline_one_chunk_only(monkeypatch):
     feeder._pending_remaining_mm = 0.0
     feeder._on_mcu_flush(flush_time=10.0, step_gen_time=10.0)
     assert len(submits) == 1
-    # Hotfix6: Submit-Distanz = interrupt_chunk_mm (default 5), nicht
-    # flush_callback_chunk_mm:
+    # Pipeline-Cap unveraendert: Submit-Distanz = interrupt_chunk_mm (5):
     assert submits[0]['distance'] == feeder.interrupt_chunk_mm
     assert feeder.interrupt_chunk_mm == 5.0  # Hotfix6 default
-    # Hotfix6: Speed = 30.0 (HALL3-Branch sanfter Initial-Fill,
-    # Konstante statt feed_speed)
-    assert submits[0]['speed'] == 30.0
+    # Hotfix7: Speed = min(max(15*1.5, 15), 30) = 22.5
+    # (statt Hotfix6 fix 30.0)
+    assert submits[0]['speed'] == pytest.approx(22.5, abs=0.1)
     # submit_chunk_cap bleibt gesetzt (defense-in-depth fuer Safety-
     # Pfade, falls _submit_move spaeter doch in Sub-Chunk-Stream
     # gerinnt — Continuous-Mode selbst nutzt kein Pending mehr):
@@ -916,22 +1128,38 @@ def test_c_cont_hotfix3_no_pending_remaining_in_continuous(monkeypatch):
 # ===========================================================================
 
 
-def test_c_cont_hotfix6_hall3_speed_constant_30(monkeypatch):
-    """Hotfix6 Layer 1: HALL3 -> 30.0 mm/s konstant (nicht feed_speed).
+def test_c_cont_hotfix7_hall3_speed_varies_with_vel(monkeypatch):
+    """Hotfix7 (ersetzt Hotfix6): HALL3-Speed skaliert mit
+    Extruder-Verbrauch statt fixer Konstante. Hotfix6 nutzte feste
+    30 mm/s -> schoss bei niedriger Print-Geschwindigkeit (vel<<15)
+    trotzdem in HALL1 over. Hotfix7: max(vel*1.5, MIN_FLOOR),
+    capped auf feed_speed.
 
-    Selbst wenn feed_speed=70 (lll.cfg) oder feed_speed=100 ist, muss
-    HALL3-Branch immer 30.0 zurueckgeben. Verhindert HALL3->HALL1
-    Durchschuss in 1 Sub-Chunk (Hardware-Beleg klippy_real.log
-    2026-05-13: 6+ Cycles HALL3->HALL1 mit feed_speed=70)."""
+    Mehrere velocity-Werte in einem Test: Tracker zwischen Calls
+    resetten, damit Sliding-Window nicht alte Samples mit neuen
+    mischt (sonst FP-Mittelwert verfaelscht Result)."""
     printer, feeder = make_c_cont_feeder(
         monkeypatch, cfg_overrides={'feed_speed': 70.0})
     set_sensor_active(feeder, 'hall_empty', True)
     set_sensor_active(feeder, 'hall_full', False)
     set_sensor_active(feeder, 'hall_overflow', False)
-    assert feeder._compute_target_feed_speed() == 30.0
-    # Selbst bei feed_speed=100 waere Output 30
+    # vel=10: 10*1.5=15, == MIN_FLOOR -> 15
+    _populate_tracker_to_ready(feeder, velocity=10.0)
+    assert feeder._compute_target_feed_speed() == pytest.approx(15.0, abs=0.1)
+    # vel=20: 20*1.5=30
+    feeder.velocity_tracker.reset()
+    _populate_tracker_to_ready(feeder, velocity=20.0)
+    assert feeder._compute_target_feed_speed() == pytest.approx(30.0, abs=0.1)
+    # vel=40: 40*1.5=60
+    feeder.velocity_tracker.reset()
+    _populate_tracker_to_ready(feeder, velocity=40.0)
+    assert feeder._compute_target_feed_speed() == pytest.approx(60.0, abs=0.1)
+    # Selbst bei feed_speed=100 cap auf feed_speed
     feeder.feed_speed = 100.0
-    assert feeder._compute_target_feed_speed() == 30.0
+    feeder.velocity_tracker.reset()
+    _populate_tracker_to_ready(feeder, velocity=80.0)
+    # 80*1.5=120 -> capped auf feed_speed=100
+    assert feeder._compute_target_feed_speed() == pytest.approx(100.0, abs=0.1)
 
 
 def test_c_cont_hotfix6_interrupt_chunk_default_5(monkeypatch):


### PR DESCRIPTION
## Problem

Hardware-Crash 2026-05-13 mit Hotfix 6 aktiv (klippy.log Z.104571):

```
stepcompress o=0 i=0 c=12 a=0: Invalid sequence
Error in syncemitter 'mellow' step generation
Exception in flush_handler → MCU-Shutdown
```

In den 80 Sekunden vor dem Crash: **16+ HALL1-OVERFLOW-Zyklen** (alle ~2s ein voller `AUTO → OVERFLOW → IDLE → AUTO`-Durchlauf). HALL2 in `buffer_metrics` **niemals** als `on` gesehen vor den HALL1-Triggern.

## Wurzel-Ursachen-Analyse

Hardware-Vermessung des Mellow LLL Plus Buffer-Feeders ergab:

| Strecke | Länge |
|---|---|
| Sensorik | optische Lichtschranken (KEINE Hall-Magnete trotz Codename) |
| HALL3 ↔ HALL2 | 12.8 mm |
| **HALL2 ↔ HALL1** | **3.6 mm** (Sicherheitsmarge!) |
| Auslöser-Fahne | 3-4 mm |
| Hebel | 2:1 (5mm Filament-Push → 2.5mm Arm-Deflektion via Schlaufe) |
| Voller Hub HALL3 → HALL1 | 16.4 mm = entspricht ~32.8mm Filament-Push |

**Bei Hotfix 6's fixem 30 mm/s + 5mm Sub-Chunk:**
- Chunk-Dauer: 167 ms
- HALL2 → HALL1 Strecke (3.6mm) bei Schwung-Geschwindigkeit überwunden in **120 ms**
- Software-Reaktionszeit (Flush-Tick): **250-500 ms**
- → **Strukturell zu langsam**, um den Arm vor HALL1 zu stoppen sobald HALL3 freigegeben wurde
- Polling-Aliasing: Auslöser passiert HALL2 zwischen zwei Buffer-Metrics-Ticks unbemerkt

## Fix-Logik

Soft-Throttle: `feed_speed` skaliert mit Extruder-Verbrauch statt fixer Konstante.

```python
HALL3:on, vel >= MIN_FLOOR:    min(max(vel*1.5, MIN_FLOOR), feed_speed)
HALL3:on, vel <  MIN_FLOOR:    MIN_FLOOR (15 mm/s)
HALL3:on, tracker not_ready:   MIN_FLOOR (Print-Start sanft)
Zwischenzone, vel >= MIN_FLOOR: min(vel*1.10, feed_speed)
Zwischenzone, vel <  MIN_FLOOR: 0 (Hotfix 5 unverändert)
HALL2:on:                      0 (Hotfix 5 unverändert)
HALL1:on:                      0 (Notbremse unverändert)
```

Bei langsamem Druck (vel=5 mm/s) schiebt der Feeder nur 15 mm/s statt 30 → Schwung-Energie halbiert → Arm bremst in HALL2-Sicherheitsfenster ab, statt HALL1 zu treffen.

**Neuer Soft-Cap auf `feed_speed`** (vs. Hotfix 3): verhindert dass `vel*1.5` oder `vel*1.10` bei schnellen Drucken über die konfigurierte Obergrenze gehen.

**FP-Boundary-Tolerance** (1e-6 Epsilon): verhindert dass `velocity_tracker`-FP-Drift an `vel == MIN_FLOOR`-Grenze auf falschen Pfad fällt.

## Begleitende Änderungen

- 10 neue TDD-Tests in `tests/test_c_cont_streaming.py`
- 9 bestehende Tests mit Hotfix-6-spezifischen Erwartungen (`== 30.0`) auf Hotfix-7-Werte aktualisiert
- 1 Lag-Verhalten-Test (`test_c_cont_hotfix7_tracker_lag_documents_tradeoff`) dokumentiert den Sliding-Window-Trade-Off explizit
- Full-Suite: **406 grün, 0 Regressionen**
- Inline-Code-Doku: ausführlicher Maintainer-Stil-Block über `_compute_target_feed_speed` mit Hardware-Beleg, Geometrie-Tabelle, Wurzel-Ursachen, Hotfix-6-Vergleich
- Spec + Plan in `docs/superpowers/{specs,plans}/2026-05-13-c-cont-hotfix7-soft-throttle.md`

## Hardware-Validierung (2026-05-14)

**Was Hotfix 7 GELÖST hat:**
- **0 HALL1-OVERFLOW-Zyklen** (vorher 16+ pro 80s) ✓
- Buffer-Arm bewegt sich visuell smooth, max ~10mm Hub (bleibt in HALL3-HALL2-Zone, 12.8mm Abstand) ✓
- Keine Unterextrusion im Highflow-Bereich ✓
- Mechanische Wurzel **eliminiert** ✓

**Was Hotfix 7 NICHT gelöst hat (Honest Disclosure):**
- Stepcompress-Crash trat nach ~850s Print-Time trotzdem auf, jetzt mit `c=3 i=0` (vorher `c=12`)
- Crash-Pattern: Pipeline pausiert (target=0 in Zwischenzone) und restartet (target=15 bei HALL3) mehrfach pro Sekunde — Wurzel 3, noch offen
- Klipper-Idle Timer-too-close beim Druckstart — siehe separater PR für Hotfix 10 (Issue #31)

## Abhängigkeiten

- Basis: `feature/c-cont-streaming` HEAD `d195376` (Hotfix 6)
- Konflikt-frei (Fast-Forward möglich)
- Hotfix 10 (separater PR, basiert auf diesem) erweitert die Hotfix-7-Pipeline um den Klipper-Idle-Fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)