### PR TITLE
fix(buffer_feeder): Hotfix 10 Refactor-Port — hall_empty-Gate fuer flush-callback-Pfad

### DIFF
--- a/klipper_extras/buffer_feeder.py
+++ b/klipper_extras/buffer_feeder.py
@@ -1120,13 +1120,42 @@ class BufferFeeder:
                     _print_active = False
                     _p778_override = True
 
+            # Hotfix 10 (Issue #31 Refactor-Port, Hardware 2026-05-14
+            # klippy.log: MCU 'LLL_PLUS' shutdown "Timer too close" beim
+            # ersten Druckstart nach Klipper-Idle, 0 Watchdog-Anchor-
+            # Fires in der gesamten Idle-Phase).
+            #
+            # P7-75 Original-Bedingung `not self.hall_empty` schuetzt
+            # vor Race mit Bang-Bang-Feed-Request. Diese Race existiert
+            # NUR im Reactor-Tick-Bang-Bang-Pfad (use_flush_callback_-
+            # bang_bang=False). Bei use_flush_callback_bang_bang=True
+            # ist _bang_bang_tick ein No-Op, Bang-Bang feuert NUR via
+            # _on_mcu_flush, der waehrend Klipper-Idle gar nicht
+            # gerufen wird (keine motion_queuing-Aktivitaet). Resultat:
+            # hall_empty=True + Klipper-Idle + flush_callback-Pfad ->
+            # kein Submit -> last_step_clock altert -> Timer too close
+            # beim ersten Print-Start-Submit nach > CLOCK_DIFF_MAX
+            # (~16.78s @ 48MHz).
+            #
+            # Fix: hall_empty-Gate nur aktiv wenn use_flush_callback_-
+            # bang_bang=False (klassischer Reactor-Tick-Pfad). Im
+            # flush-callback-Pfad muss Watchdog auch bei hall_empty
+            # feuern. Andere Sub-Gates (_continuous_feed, hall_full,
+            # _needs_overflow_prime) bleiben unveraendert — kein Race
+            # mit aktivem Stream, kein Forward-Feed in vollen Buffer.
+            #
+            # Siehe tests/test_idle_watchdog_anchor.py:
+            #   test_watchdog_fires_in_auto_with_hall_empty_when_flush_callback_bangbang
+            #   test_watchdog_still_blocks_in_auto_with_hall_empty_when_classic_bangbang
+            hall_empty_block = (self.hall_empty
+                                and not self.use_flush_callback_bang_bang)
             if (self._state in (STATE_IDLE, STATE_AUTO)
                     and not self._stepper_synced_to
                     and not self._pending_disable
                     and not self._move_in_flight()
                     and self._pending_remaining_mm == 0.0
                     and not self._continuous_feed
-                    and not self.hall_empty
+                    and not hall_empty_block
                     and not self.hall_full
                     and not self._needs_overflow_prime
                     and not _print_active):  # P7-77 A + P7-78 Override

--- a/tests/test_idle_watchdog_anchor.py
+++ b/tests/test_idle_watchdog_anchor.py
@@ -298,3 +298,103 @@ def test_anchor_after_two_full_windows_fires_again(monkeypatch):
     assert len(calls) == 2, (
         "After a full idle_anchor_gap elapses since the previous "
         "anchor, the watchdog must re-fire.")
+
+
+# ---------------------------------------------------------------------------
+# Issue #31 Refactor-Port Regression: Watchdog vs. hall_empty + flush_callback
+# ---------------------------------------------------------------------------
+#
+# Hotfix 10 (Hardware 2026-05-14, klippy.log Z.363): MCU 'LLL_PLUS' shutdown
+# "Timer too close" beim ersten Druckstart nach Klipper-Idle (gap=257.7s).
+#
+# Wurzel: Der P7-75 Sub-Gate `not self.hall_empty` blockierte den Watchdog
+# auch im flush-callback-bang-bang-Pfad (use_flush_callback_bang_bang=True).
+# Dort ist `_bang_bang_tick` ein No-Op — der Race vor dem das Gate
+# schuetzen sollte (Bang-Bang-Feed-Request vs. Watchdog-Anchor) existiert
+# nur im klassischen Reactor-Tick-Pfad. Im flush-callback-Pfad ist der
+# Watchdog die EINZIGE Schutzschicht gegen stale last_step_clock waehrend
+# Klipper-Idle (kein motion_queuing-Callback ohne Steps).
+#
+# Fix: hall_empty-Gate konditional an use_flush_callback_bang_bang=False
+# binden. Mit flush_callback_bang_bang=True (= C-cont Streaming-Modus)
+# feuert der Watchdog auch bei hall_empty=True.
+#
+# Status: Im Refactor (Commit 02e9b33) wurde nur Teil 2 von Hotfix 10
+# portiert (Idle-Suppression in _on_mcu_flush). Teil 1 (Watchdog-Gate-
+# Anpassung) fehlt — diese Tests sind die TDD-Regression.
+
+
+def test_watchdog_fires_in_auto_with_hall_empty_when_flush_callback_bangbang(
+        monkeypatch):
+    """Hotfix 10 (Issue #31 Refactor-Port-Regression):
+    Im flush-callback-bang-bang-Pfad (use_flush_callback_bang_bang=True)
+    muss der Watchdog auch bei hall_empty=True feuern.
+
+    Pre-condition fuer den realen Hardware-Crash:
+      - state=AUTO, kein Druck aktiv (print_stats=standby)
+      - hall_empty=True (Buffer-Arm in entrance-Position, normales Idle)
+      - use_flush_callback_bang_bang=True (C-cont Streaming-Modus)
+      - _continuous_feed=False (Bang-Bang nicht aktiv)
+      - gap > idle_anchor_gap
+
+    Ohne Fix bleibt last_step_clock stale → erster Submit nach PRINT_START
+    crasht mit Timer-too-close. Mit Fix feuert der Watchdog regelmaessig
+    den 0.05mm-Micro-Anchor und haelt den Cursor frisch.
+
+    Hardware-Beleg: klippy_refactor_timer_too_close.log Z.3086 (clock=
+    4052274463, 0 'auto anchor fired' Events in der gesamten Idle-Phase).
+    """
+    _, feeder = make_idle_feeder(
+        values={'use_flush_callback_bang_bang': True})
+    feeder._state = buffer_feeder.STATE_AUTO
+    # Bang-Bang muss quiescent sein (sonst greift der continuous_feed-Gate).
+    feeder._continuous_feed = False
+    # hall_empty=True simuliert Filament-im-Buffer-Idle: Arm haengt in
+    # entrance-Position.
+    set_sensor_active(feeder, 'hall_empty', True)
+    set_sensor_active(feeder, 'hall_full', False)
+    set_sensor_active(feeder, 'hall_overflow', False)
+
+    calls = count_anchor_calls(monkeypatch, feeder)
+    feeder.reactor.now = 20.0
+    feeder._last_move_end_time = 0.0
+    feeder._main_tick(eventtime=20.0)
+
+    assert len(calls) == 1, (
+        "Hotfix 10: Watchdog MUSS in STATE_AUTO mit hall_empty=True "
+        "feuern, wenn use_flush_callback_bang_bang=True. Ohne diesen "
+        "Anchor altert last_step_clock waehrend Klipper-Idle und der "
+        "erste Submit nach PRINT_START crasht mit Timer-too-close.")
+
+
+def test_watchdog_still_blocks_in_auto_with_hall_empty_when_classic_bangbang(
+        monkeypatch):
+    """Regression P7-75 klassischer Pfad: bei use_flush_callback_bang_-
+    bang=False bleibt das hall_empty-Gate aktiv.
+
+    Hier laeuft _bang_bang_tick im Reactor-Tick als echter Submitter.
+    Ein Watchdog-Anchor parallel dazu wuerde mit dem Bang-Bang-Feed-
+    Request racen — genau der Race vor dem P7-75 urspruenglich
+    geschuetzt hatte. Das Gate muss in diesem Pfad weiter blocken.
+    """
+    _, feeder = make_idle_feeder(
+        values={'use_flush_callback_bang_bang': False})
+    feeder._state = buffer_feeder.STATE_AUTO
+    feeder._continuous_feed = False
+    set_sensor_active(feeder, 'hall_empty', True)
+    set_sensor_active(feeder, 'hall_full', False)
+    set_sensor_active(feeder, 'hall_overflow', False)
+    # Bang-bang-tick patchen um Observation eng zu halten (existierendes
+    # Pattern in test_state_auto_with_active_bangbang_does_not_fire).
+    monkeypatch.setattr(feeder, "_bang_bang_tick", lambda et: None)
+
+    calls = count_anchor_calls(monkeypatch, feeder)
+    feeder.reactor.now = 20.0
+    feeder._last_move_end_time = 0.0
+    feeder._main_tick(eventtime=20.0)
+
+    assert calls == [], (
+        "P7-75 klassischer Reactor-Tick-Pfad: hall_empty-Gate muss "
+        "Watchdog weiter blocken, wenn use_flush_callback_bang_bang="
+        "False. Sonst race zwischen Watchdog-Anchor und Bang-Bang-"
+        "Feed-Request im _bang_bang_tick.")


### PR DESCRIPTION
## Problem

Im flush-callback-bang-bang-Pfad (`use_flush_callback_bang_bang=True`) blockiert der P7-75 Watchdog-Sub-Gate `not self.hall_empty` den Idle-Watchdog auch dort, wo er die einzige Schutzschicht gegen stale `last_step_clock` ist.

Hardware-Reproduktion auf `refactor/cleanup-all-phases` (Commit `97e97e7`):
- Drucker idle mit `hall=[H3:on H2:off H1:off]` (Buffer-Arm in entrance-Position → `hall_empty=True`)
- >30s ohne `auto anchor fired` Events (Watchdog blockiert)
- Erster Druckstart: `MCU 'LLL_PLUS' shutdown: Timer too close` (stepcompress-Cursor > CLOCK_DIFF_MAX ~16.78s @ 48MHz alt)

Maintainer-Commit `97e97e7` ("guard forced_t0 against stale future floors") fängt das nicht, weil die Sanitization nur auf `_last_move_end_time > mcu_now + MAX_T0_LOOKAHEAD_S` zielt (stale Zukunft). Hier ist `_last_move_end_time` weit in der **Vergangenheit** und der echte stepcompress-Cursor auf MCU-Seite ist alt — kein Python-Floor-Reset löst das.

## Fix

P7-75 Original-Bedingung `not self.hall_empty` schützt vor Race mit Bang-Bang-Feed-Request. Diese Race existiert **nur** im klassischen Reactor-Tick-Pfad (`use_flush_callback_bang_bang=False`). Bei `=True` ist `_bang_bang_tick` ein No-Op, Bang-Bang feuert nur via `_on_mcu_flush` — der während Klipper-Idle gar nicht gerufen wird (keine `motion_queuing`-Aktivitaet).

Lösung: `hall_empty`-Gate konditional an `use_flush_callback_bang_bang=False` binden.

```python
hall_empty_block = (self.hall_empty
                    and not self.use_flush_callback_bang_bang)
if (...
        and not hall_empty_block       # statt: not self.hall_empty
        ...):
```

Im flush-callback-Pfad feuert der Watchdog jetzt auch bei `hall_empty=True`. Andere Sub-Gates (`_continuous_feed`, `hall_full`, `_needs_overflow_prime`) bleiben unverändert — kein Race mit aktivem Stream, kein Forward-Feed in vollen Buffer.

## Begleitende Aenderungen

- **TDD (Phase 3, Iron Law eingehalten):**
  - RED: `test_watchdog_fires_in_auto_with_hall_empty_when_flush_callback_bangbang` (Watchdog feuert nicht, 0 statt 1 Aufruf)
  - GREEN nach Fix: beide neue Tests pass
  - Zusätzlich Regression-Test: `test_watchdog_still_blocks_in_auto_with_hall_empty_when_classic_bangbang` (klassischer Reactor-Tick-Pfad bleibt geschützt)
- **Full-Suite:** 403 → 405 passed (0 Regressionen). Maintainer's `97e97e7` Tests bleiben grün.
- **Hardware-Belege:** Zwei Drucker-Tests dokumentiert:
  1. Vor Fix (Stand `a9c12b1`): Timer too close beim Druckstart nach Idle
  2. Mit Fix: regelmäßige `auto anchor fired` Events, Druckstart sauber durch
  3. Mit `97e97e7` allein (ohne diesen Fix): Timer too close reproduziert

## Abhaengigkeiten

- Baut auf `refactor/cleanup-all-phases` HEAD (`97e97e7`) auf.
- Komplementär zu `97e97e7` (`guard forced_t0 against stale future floors`):
  - `97e97e7` behandelt stale-**Zukunft**-Floors (lme/lest weit voraus → forced_t0 wird überschrieben)
  - Dieser Fix behandelt stale-**Vergangenheit**-Cursor (`last_step_clock` altert während Idle → Timer too close)
- Beide Fixes zusammen = Defense-in-depth für die Timer-too-close-Klassen im flush-callback-Pfad.