### PR TITLE
fix(buffer_feeder): Cursor-Freshness-Contract — Pre-Anchor vor stalem streaming-Submit (HW-Test ausstehend)

### DIFF
--- a/klipper_extras/_buffer_common.py
+++ b/klipper_extras/_buffer_common.py
@@ -70,6 +70,22 @@ REPRIME_GAP_S = 5.0
 # als stale verworfen.
 MAX_T0_LOOKAHEAD_S = 2.0
 
+# Maximales Alter von _last_move_end_time (Python-Proxy fuer MCU-side
+# last_step_clock), bevor ein streaming-Submit aus _on_mcu_flush einen
+# garantierten Cursor-Freshness-Anchor (0.05mm @ feed_speed) vorne
+# anstellt. Begruendung:
+#   - Streaming-Submit nach langer Idle-Phase produziert
+#     queue_step interval = (mcu_now + lead_time) - last_step_clock,
+#     was bei Watchdog-Anchor-Lueck (bis ~10s) mit USB-Sende-Latenz
+#     + MCU-busy in "Step in der Vergangenheit"-Race kippen kann
+#     (Hardware-Beleg 2026-05-14: Timer too close beim ersten
+#     streaming-Submit nach PRINT_START).
+#   - 1.0s ist klein genug, dass nach Anchor (5ms duration) der
+#     naechste Submit-Step << CLOCK_DIFF_MAX (~16.78s) bleibt;
+#     gross genug, dass die uebliche Submit-Kadenz keinen Pseudo-
+#     Anchor jedes Mal triggert.
+MIN_CURSOR_FRESHNESS_S = 1.0
+
 
 # ---------------------------------------------------------------------------
 # Click / button identifiers

--- a/klipper_extras/buffer_feeder.py
+++ b/klipper_extras/buffer_feeder.py
@@ -1120,13 +1120,42 @@ class BufferFeeder:
                     _print_active = False
                     _p778_override = True
 
+            # Hotfix 10 (Issue #31 Refactor-Port, Hardware 2026-05-14
+            # klippy.log: MCU 'LLL_PLUS' shutdown "Timer too close" beim
+            # ersten Druckstart nach Klipper-Idle, 0 Watchdog-Anchor-
+            # Fires in der gesamten Idle-Phase).
+            #
+            # P7-75 Original-Bedingung `not self.hall_empty` schuetzt
+            # vor Race mit Bang-Bang-Feed-Request. Diese Race existiert
+            # NUR im Reactor-Tick-Bang-Bang-Pfad (use_flush_callback_-
+            # bang_bang=False). Bei use_flush_callback_bang_bang=True
+            # ist _bang_bang_tick ein No-Op, Bang-Bang feuert NUR via
+            # _on_mcu_flush, der waehrend Klipper-Idle gar nicht
+            # gerufen wird (keine motion_queuing-Aktivitaet). Resultat:
+            # hall_empty=True + Klipper-Idle + flush_callback-Pfad ->
+            # kein Submit -> last_step_clock altert -> Timer too close
+            # beim ersten Print-Start-Submit nach > CLOCK_DIFF_MAX
+            # (~16.78s @ 48MHz).
+            #
+            # Fix: hall_empty-Gate nur aktiv wenn use_flush_callback_-
+            # bang_bang=False (klassischer Reactor-Tick-Pfad). Im
+            # flush-callback-Pfad muss Watchdog auch bei hall_empty
+            # feuern. Andere Sub-Gates (_continuous_feed, hall_full,
+            # _needs_overflow_prime) bleiben unveraendert — kein Race
+            # mit aktivem Stream, kein Forward-Feed in vollen Buffer.
+            #
+            # Siehe tests/test_idle_watchdog_anchor.py:
+            #   test_watchdog_fires_in_auto_with_hall_empty_when_flush_callback_bangbang
+            #   test_watchdog_still_blocks_in_auto_with_hall_empty_when_classic_bangbang
+            hall_empty_block = (self.hall_empty
+                                and not self.use_flush_callback_bang_bang)
             if (self._state in (STATE_IDLE, STATE_AUTO)
                     and not self._stepper_synced_to
                     and not self._pending_disable
                     and not self._move_in_flight()
                     and self._pending_remaining_mm == 0.0
                     and not self._continuous_feed
-                    and not self.hall_empty
+                    and not hall_empty_block
                     and not self.hall_full
                     and not self._needs_overflow_prime
                     and not _print_active):  # P7-77 A + P7-78 Override

--- a/klipper_extras/buffer_feeder.py
+++ b/klipper_extras/buffer_feeder.py
@@ -36,8 +36,8 @@ from ._buffer_common import (
     ANCHOR_NUDGE_MM, BUSY_PHASE_STATES, BUTTON_FEED, BUTTON_RETRACT,
     CLICK_DOUBLE, CLICK_SINGLE, CLICK_TRIPLE,
     CONTINUOUS_FEED_STATES, JAM_TICK_INTERVAL, JAM_WATCH_STATES,
-    MAIN_TICK_INTERVAL, MAX_T0_LOOKAHEAD_S, REPRIME_GAP_S,
-    STABLE_DROP_GRACE,
+    MAIN_TICK_INTERVAL, MAX_T0_LOOKAHEAD_S, MIN_CURSOR_FRESHNESS_S,
+    REPRIME_GAP_S, STABLE_DROP_GRACE,
     STATE_AUTO, STATE_IDLE, STATE_INIT, STATE_INITIAL_GRIP,
     STATE_JAM, STATE_LOADING_PULL, STATE_LOADING_PUSH,
     STATE_MANUAL_FEED, STATE_MANUAL_RETRACT, STATE_OVERFLOW,
@@ -1790,6 +1790,43 @@ class BufferFeeder:
                 "skip pending_remaining_mm=%.3f",
                 self._pending_remaining_mm, min_interval=1.0)
             return  # sub-chunk pipeline already running
+
+        # Cursor-Freshness-Contract (Hardware-Beleg 2026-05-14
+        # klippy_refactor_*_repro.log): wenn kein move in flight UND
+        # _last_move_end_time aelter als MIN_CURSOR_FRESHNESS_S, dann
+        # ist die MCU-side last_step_clock potenziell ueber USB-Sende-
+        # Latenz + MCU-busy in "Step in der Vergangenheit"-Race
+        # anfaellig (queue_step interval = mcu_now + lead_time -
+        # last_step_clock). Watchdog-Anchor alle 10s ist best-effort,
+        # schliesst aber das Race-Window nicht; PR #39 Watchdog-Fix
+        # haelt Cursor im IDLE frisch, aber das Race-Window zwischen
+        # Watchdog-Anchor und erstem streaming-Submit nach PRINT_START
+        # bleibt.
+        #
+        # Fix: pre-anchor (0.05mm @ feed_speed) als garantierter
+        # Cursor-Refresh vor dem streaming-Submit, wenn cursor zu alt.
+        # forced_t0 wird intern (siehe _plan_t0_anchor) auf
+        # mcu_now + lead_time geclampt — anchor landet sicher in
+        # naher Zukunft, last_step_clock danach <= lead_time alt.
+        # Effekt: queue_step interval fuer den danach folgenden
+        # streaming-Submit << 1s, race-frei unter jeder USB-Latenz.
+        #
+        # Komplementaer zu PR #39 (Watchdog-Hall-Empty-Bypass) und
+        # 97e97e7 (sanitize stale-future-floors). Defense-in-depth.
+        if not move_active:
+            mcu_now = self.stepper.get_mcu().estimated_print_time(
+                self.reactor.monotonic())
+            cursor_age = mcu_now - self._last_move_end_time
+            if cursor_age > MIN_CURSOR_FRESHNESS_S:
+                self._debug_event(
+                    'flush_freshness_anchor',
+                    "pre-anchor cursor_age=%.2fs > %.2fs threshold",
+                    cursor_age, MIN_CURSOR_FRESHNESS_S, min_interval=2.0)
+                anchor_dir = -1.0 if self.hall_overflow else 1.0
+                self._submit_move(
+                    anchor_dir * ANCHOR_NUDGE_MM,
+                    self.feed_speed,
+                    forced_t0=step_gen_time + self.lead_time)
 
         if move_active:
             anchor = self._last_move_end_time

--- a/klipper_extras/buffer_feeder.py
+++ b/klipper_extras/buffer_feeder.py
@@ -1791,28 +1791,31 @@ class BufferFeeder:
                 self._pending_remaining_mm, min_interval=1.0)
             return  # sub-chunk pipeline already running
 
-        # Cursor-Freshness-Contract (Hardware-Beleg 2026-05-14
-        # klippy_refactor_*_repro.log): wenn kein move in flight UND
-        # _last_move_end_time aelter als MIN_CURSOR_FRESHNESS_S, dann
-        # ist die MCU-side last_step_clock potenziell ueber USB-Sende-
-        # Latenz + MCU-busy in "Step in der Vergangenheit"-Race
-        # anfaellig (queue_step interval = mcu_now + lead_time -
-        # last_step_clock). Watchdog-Anchor alle 10s ist best-effort,
-        # schliesst aber das Race-Window nicht; PR #39 Watchdog-Fix
-        # haelt Cursor im IDLE frisch, aber das Race-Window zwischen
-        # Watchdog-Anchor und erstem streaming-Submit nach PRINT_START
-        # bleibt.
+        # Cursor-Freshness-Contract D2 (Hardware-Belege 2026-05-14):
         #
-        # Fix: pre-anchor (0.05mm @ feed_speed) als garantierter
-        # Cursor-Refresh vor dem streaming-Submit, wenn cursor zu alt.
-        # forced_t0 wird intern (siehe _plan_t0_anchor) auf
-        # mcu_now + lead_time geclampt — anchor landet sicher in
-        # naher Zukunft, last_step_clock danach <= lead_time alt.
-        # Effekt: queue_step interval fuer den danach folgenden
-        # streaming-Submit << 1s, race-frei unter jeder USB-Latenz.
+        # Lauf 1 (klippy_refactor_*_repro.log): ohne pre-anchor sah
+        # _flush_submit_streaming_chunk einen 7-10s alten Cursor und
+        # submittete den streaming-chunk mit forced_t0 weit voraus —
+        # queue_step interval=332M Ticks (6.92s) -> Timer too close.
+        #
+        # Lauf 2 (klippy_combined_fix_crash.log): pre-anchor +
+        # streaming-Submit IN DERSELBEN flush-callback brachten beide
+        # queue_step-Bursts plus TMC-UART-Reads in einen USB-Burst
+        # (Sent 83-97 alle innerhalb 58ms). MCU-CPU-busy + USB-Latenz
+        # frassen den lead_time-Buffer auf; Pre-Anchor-Step war beim
+        # MCU-Receive bereits in der Vergangenheit -> Timer too close.
+        #
+        # D2 Fix: Pre-Anchor allein in dieser flush-callback, SOFORT
+        # return. Streaming-Submit erfolgt im NAECHSTEN flush-callback
+        # via P7-66 Lookahead-Pfad (move_in_flight=True, abuttend an
+        # _last_move_end_time). MCU bekommt die queue_step-Bytes des
+        # Pre-Anchors und des Streaming-Submits in zwei getrennten
+        # USB-Bursts mit ausreichendem Verarbeitungs-Buffer dazwischen
+        # (typisch 10-25ms via motion_queuing.flush_handler).
         #
         # Komplementaer zu PR #39 (Watchdog-Hall-Empty-Bypass) und
         # 97e97e7 (sanitize stale-future-floors). Defense-in-depth.
+        # Siehe tests/test_cursor_freshness_before_submit.py.
         if not move_active:
             mcu_now = self.stepper.get_mcu().estimated_print_time(
                 self.reactor.monotonic())
@@ -1820,13 +1823,18 @@ class BufferFeeder:
             if cursor_age > MIN_CURSOR_FRESHNESS_S:
                 self._debug_event(
                     'flush_freshness_anchor',
-                    "pre-anchor cursor_age=%.2fs > %.2fs threshold",
+                    "deferred-anchor cursor_age=%.2fs > %.2fs "
+                    "threshold (D2: streaming auf naechste flush "
+                    "verschoben)",
                     cursor_age, MIN_CURSOR_FRESHNESS_S, min_interval=2.0)
                 anchor_dir = -1.0 if self.hall_overflow else 1.0
                 self._submit_move(
                     anchor_dir * ANCHOR_NUDGE_MM,
                     self.feed_speed,
                     forced_t0=step_gen_time + self.lead_time)
+                # D2: return statt continue — streaming-Submit erfolgt
+                # im naechsten flush-callback via P7-66 Lookahead-Pfad.
+                return
 
         if move_active:
             anchor = self._last_move_end_time

--- a/tests/test_cursor_freshness_before_submit.py
+++ b/tests/test_cursor_freshness_before_submit.py
@@ -1,0 +1,319 @@
+"""Cursor-Freshness-Contract — garantierte last_step_clock-Frische vor
+jedem streaming-Submit aus _on_mcu_flush.
+
+Hardware-Beleg (2026-05-14 klippy_refactor_*_repro.log):
+
+  buffer_feeder: auto anchor fired (4× in der Idle-Phase mit hall_empty=True,
+                                    Watchdog-Fix aus PR #39 wirkt)
+  ... 8× buffer_metrics (idle continues)
+  Starting SD card print (position 0)
+  buffer_event[flush_submit]: anchor=58.698 move_active=False chunk=9.000
+  SET_KINEMATIC_POSITION pos=0.000,0.000,0.000 set_homed=xyz
+  → MCU 'LLL_PLUS' shutdown: Timer too close
+
+Send-Queue-Beleg: queue_step oid=0 interval=332180349 count=1 add=0
+  (6.92s zwischen letztem Watchdog-Anchor und erstem Submit-Step). Mit
+  USB-Sende-Latenz + MCU-busy (TMC-UART-Storm in derselben Send-Sequenz)
+  landet der erste Step in der Vergangenheit relativ zur MCU-Clock zum
+  Receive-Zeitpunkt → Timer too close.
+
+Wurzel: _on_mcu_flush hat keinen Vertrag wie alt last_step_clock sein
+darf, bevor ein streaming-Submit ausgeloest wird. Watchdog feuert alle
+~10s als best-effort, schliesst aber das Race-Window nicht. Wenn
+streaming-Demand zwischen zwei Watchdog-Anchors landet (z.B. PRINT_START
+oeffnet das Idle-Suppression-Gate via state='printing'), schickt
+_flush_submit_streaming_chunk einen Move auf einen 7-10s alten Cursor.
+
+Fix-Vertrag (Phase 3 TDD): _flush_submit_streaming_chunk sichert vor
+JEDEM eigentlichen Streaming-Submit einen garantierten anchor-Step,
+wenn _last_move_end_time aelter als MIN_CURSOR_FRESHNESS_S ist und kein
+move_in_flight laeuft. Effekt: queue_step interval ist nach dem
+Pre-Anchor << 1s — keine Race-Anfaelligkeit mehr fuer Timer-too-close
+in dieser Wurzel-Klasse.
+
+Komplementaer zu:
+  - PR #39 (Watchdog feuert bei hall_empty=True im flush_callback-Pfad)
+    schuetzt vor Idle-Stale-Cursor in STATE_AUTO ausserhalb von Prints.
+  - Maintainer 97e97e7 (sanitize_forced_t0_floors) schuetzt vor
+    stale-Future-Floors die forced_t0 ueberschreiben.
+
+Defense-in-depth — drei orthogonale Schutzschichten.
+"""
+
+import pytest
+
+from fakes_klipper import FakeConfig, FakePrinter, FakePrintStats
+from klipper_extras import buffer_feeder
+from klipper_extras._buffer_common import (
+    ANCHOR_NUDGE_MM, MIN_CURSOR_FRESHNESS_S,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers (Pattern aus test_streaming_pipeline_auto.py)
+# ---------------------------------------------------------------------------
+
+
+def set_sensor_active(feeder, sensor_name, active):
+    polarity_flip = feeder._pin_polarity_flip[sensor_name]
+    raw = (not active) if polarity_flip else active
+    feeder._pin_stable_state[sensor_name] = raw
+    feeder._pin_raw_state[sensor_name] = raw
+
+
+def make_streaming_feeder(values=None, print_state='printing'):
+    """Feeder bereit fuer flush-callback streaming submits."""
+    base = {"use_flush_callback_bang_bang": True}
+    if values:
+        base.update(values)
+    printer = FakePrinter()
+    printer.objects["print_stats"] = FakePrintStats(state=print_state)
+    config = FakeConfig(printer=printer, values=base)
+    feeder = buffer_feeder.BufferFeeder(config)
+    printer.fire_event('klippy:connect')
+    feeder._startup_grace_done = True
+    feeder._state = buffer_feeder.STATE_AUTO
+    set_sensor_active(feeder, 'hall_overflow', False)
+    set_sensor_active(feeder, 'hall_full', False)
+    set_sensor_active(feeder, 'hall_empty', True)  # demand triggers MIN_FLOOR
+    # ExtruderVelocityTracker zu ready bringen damit target_speed > 0
+    fake_ext = printer.objects['extruder']
+    fake_ext.last_position = 0.0
+    t = 0.0
+    for _ in range(12):
+        fake_ext.last_position = t * 15.0  # 15 mm/s extruder velocity
+        feeder.velocity_tracker.tick(t)
+        t += 0.025
+    feeder._stepcompress_primed = True
+    return printer, feeder
+
+
+def own_trapq_appends(motion_q, feeder, before_count):
+    """Filter trapq_append-Calls die auf feeder.trapq gingen."""
+    return [c for c in motion_q.append_calls[before_count:]
+            if c[0] is feeder.trapq]
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: Wurzel-Fall — stale cursor + streaming demand
+# ---------------------------------------------------------------------------
+
+
+def test_freshness_anchor_fires_when_cursor_stale_and_no_move_in_flight():
+    """Wurzel-Fall: _last_move_end_time ist >MIN_CURSOR_FRESHNESS_S
+    alt, kein move in flight, streaming demand vorhanden
+    (hall_empty=True). Erwartung: ZWEI trapq_append-Calls — zuerst
+    ein Anchor-Step (Cursor-Refresh, 0.05mm), dann der eigentliche
+    streaming chunk (interrupt_chunk_mm).
+
+    Pre-Fix: nur EIN append (streaming submit mit interval > 1s).
+    Hardware-Crash: queue_step interval=332M Ticks (6.92s) → Timer
+    too close beim ersten Submit nach PRINT_START.
+    """
+    printer, feeder = make_streaming_feeder()
+    motion_q = printer.lookup_object('motion_queuing')
+
+    # mcu_now = 10.0, lme = 0.0 -> age = 10s > 1.0s
+    feeder.reactor.now = 10.0
+    feeder._last_move_end_time = 0.0
+    feeder._current_move = None  # nicht in flight
+
+    appends_before = len(motion_q.append_calls)
+    motion_q.trigger_flush(flush_time=10.0, step_gen_time=10.0)
+    own = own_trapq_appends(motion_q, feeder, appends_before)
+
+    assert len(own) == 2, (
+        "Erwartung: Cursor-Freshness-Anchor zuerst, dann streaming "
+        "submit (2 own_trapq appends). Erhalten: %d" % len(own))
+    # Erstes append = Anchor (0.05mm, kleine Distanz im accel/cruise/decel)
+    anchor_call = own[0]
+    streaming_call = own[1]
+    # axes_r ist Argument 9 in trapq_append signature (x-Komponente):
+    # (trapq, t0, accel_time, cruise_time, decel_time,
+    #  start_pos_x, _, _, axes_r_x, _, _, start_v, cruise_v, accel)
+    # Anchor sollte deutlich kleinere Bewegungszeit haben als Streaming.
+    anchor_total_time = anchor_call[2] + anchor_call[3] + anchor_call[4]
+    streaming_total_time = (streaming_call[2] + streaming_call[3]
+                            + streaming_call[4])
+    assert anchor_total_time < streaming_total_time, (
+        "Anchor-Move soll kuerzer sein als streaming chunk. "
+        "Anchor=%.4fs Streaming=%.4fs" % (anchor_total_time,
+                                          streaming_total_time))
+
+
+def test_no_freshness_anchor_when_cursor_fresh():
+    """Cursor < MIN_CURSOR_FRESHNESS_S alt: kein Pre-Anchor noetig,
+    nur normaler streaming submit."""
+    printer, feeder = make_streaming_feeder()
+    motion_q = printer.lookup_object('motion_queuing')
+
+    # mcu_now = 10.0, lme = 9.5 -> age = 0.5s < 1.0s
+    feeder.reactor.now = 10.0
+    feeder._last_move_end_time = 9.5
+    feeder._current_move = None
+
+    appends_before = len(motion_q.append_calls)
+    motion_q.trigger_flush(flush_time=10.0, step_gen_time=10.0)
+    own = own_trapq_appends(motion_q, feeder, appends_before)
+
+    assert len(own) == 1, (
+        "Bei frischem Cursor (age<%.1fs): nur streaming submit, kein "
+        "Pre-Anchor. Erhalten: %d appends"
+        % (MIN_CURSOR_FRESHNESS_S, len(own)))
+
+
+def test_no_freshness_anchor_when_move_in_flight():
+    """move_in_flight: Cursor wird durch laufenden Move ohnehin
+    frisch gehalten — kein Pre-Anchor noetig. Falls Stream-Demand
+    da ist, normaler Lookahead-Submit (abuttend an lme)."""
+    printer, feeder = make_streaming_feeder()
+    motion_q = printer.lookup_object('motion_queuing')
+
+    # move in flight: lme > mcu_now
+    feeder.reactor.now = 10.0
+    feeder._last_move_end_time = 10.20
+    feeder._current_move = {
+        'end_time': 10.20, 'direction': 1.0,
+        'distance': 9.0, 'speed': feeder.feed_speed,
+    }
+
+    appends_before = len(motion_q.append_calls)
+    # step_gen_time so dass remaining = lme - sg = 0.10 <= lead_time
+    motion_q.trigger_flush(flush_time=10.0, step_gen_time=10.10)
+    own = own_trapq_appends(motion_q, feeder, appends_before)
+
+    assert len(own) == 1, (
+        "move_in_flight=True: nur streaming submit (Lookahead), "
+        "kein Pre-Anchor. Erhalten: %d appends" % len(own))
+
+
+def test_no_freshness_anchor_when_target_speed_zero():
+    """Kein Demand (target_speed=0, hall_full -> drain-Branch): kein
+    streaming submit, daher auch kein Pre-Anchor. Cursor-Freshness
+    bleibt ausschliesslich in der Verantwortung des Watchdogs in
+    diesem Pfad. hall_full=True zwingt _compute_target_feed_speed
+    auf 0 (Buffer voll, kein Push)."""
+    printer, feeder = make_streaming_feeder()
+    motion_q = printer.lookup_object('motion_queuing')
+
+    # hall_full=True -> _compute_target_feed_speed=0 (drain via toolhead)
+    set_sensor_active(feeder, 'hall_empty', False)
+    set_sensor_active(feeder, 'hall_full', True)
+    set_sensor_active(feeder, 'hall_overflow', False)
+    # Sanity check: tracker liefert weiter velocity, aber hall_full
+    # Branch dominiert -> target_speed=0.
+    assert feeder._compute_target_feed_speed() == 0.0
+
+    feeder.reactor.now = 10.0
+    feeder._last_move_end_time = 0.0  # stale
+    feeder._current_move = None
+
+    appends_before = len(motion_q.append_calls)
+    motion_q.trigger_flush(flush_time=10.0, step_gen_time=10.0)
+    own = own_trapq_appends(motion_q, feeder, appends_before)
+
+    assert len(own) == 0, (
+        "Bei target_speed=0 (kein demand): weder Pre-Anchor noch "
+        "streaming submit. Erhalten: %d appends" % len(own))
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Anchor-Eigenschaften — direction, distance, refresh
+# ---------------------------------------------------------------------------
+
+
+def test_freshness_anchor_distance_is_anchor_nudge_mm():
+    """Der Pre-Anchor verwendet ANCHOR_NUDGE_MM (0.05mm) — minimal
+    physisch spuerbar, aber genug fuer cursor refresh. axes_r_x +
+    Trapezoid-Profile lassen sich daraus rekonstruieren: distance =
+    0.5*cruise_v*(accel_time+decel_time) + cruise_v*cruise_time."""
+    printer, feeder = make_streaming_feeder()
+    motion_q = printer.lookup_object('motion_queuing')
+
+    feeder.reactor.now = 10.0
+    feeder._last_move_end_time = 0.0
+    feeder._current_move = None
+
+    appends_before = len(motion_q.append_calls)
+    motion_q.trigger_flush(flush_time=10.0, step_gen_time=10.0)
+    own = own_trapq_appends(motion_q, feeder, appends_before)
+
+    assert len(own) >= 1, "Anchor muss gefeuert haben"
+    anchor_call = own[0]
+    # Trapq-Append-Signatur, accel_time=arg[2], cruise_time=arg[3],
+    # decel_time=arg[4], cruise_v=arg[12], accel=arg[13].
+    accel_time = anchor_call[2]
+    cruise_time = anchor_call[3]
+    decel_time = anchor_call[4]
+    cruise_v = anchor_call[12]
+    accel_dist = 0.5 * cruise_v * accel_time
+    decel_dist = 0.5 * cruise_v * decel_time
+    cruise_dist = cruise_v * cruise_time
+    total_dist = accel_dist + cruise_dist + decel_dist
+    assert total_dist == pytest.approx(ANCHOR_NUDGE_MM, abs=0.001), (
+        "Anchor-Distanz muss ANCHOR_NUDGE_MM=%.3fmm sein. "
+        "Erhalten: %.4fmm" % (ANCHOR_NUDGE_MM, total_dist))
+
+
+def test_freshness_anchor_direction_positive_in_normal_demand():
+    """Im normalen Demand-Pfad (kein hall_overflow): Anchor laeuft
+    in feed-direction (positiv). hall_overflow=True ist ein
+    separater Pfad — der flush-callback hat dafuer einen
+    Hall1Context.SUBMIT_MOVE early-return weiter oben."""
+    printer, feeder = make_streaming_feeder()
+    motion_q = printer.lookup_object('motion_queuing')
+    # Default: hall_overflow=False bereits via make_streaming_feeder
+
+    feeder.reactor.now = 10.0
+    feeder._last_move_end_time = 0.0
+    feeder._current_move = None
+
+    appends_before = len(motion_q.append_calls)
+    motion_q.trigger_flush(flush_time=10.0, step_gen_time=10.0)
+    own = own_trapq_appends(motion_q, feeder, appends_before)
+
+    assert len(own) == 2, "Anchor + streaming expected"
+    anchor_call = own[0]
+    # direction (axes_r_x) = Argument 8 (0-indexed) in trapq_append:
+    # (trapq, t0, accel_time, cruise_time, decel_time,
+    #  start_pos_x, _, _, axes_r_x, _, _, start_v, cruise_v, accel)
+    axes_r_x = anchor_call[8]
+    assert axes_r_x > 0, (
+        "Im normalen Demand-Pfad (hall_overflow=False) muss anchor "
+        "feed-direction (positiv) laufen. axes_r_x=%.2f" % axes_r_x)
+
+
+def test_freshness_anchor_advances_last_move_end_time():
+    """Nach dem Pre-Anchor muss _last_move_end_time auf
+    anchor_t0 + anchor_duration vorruecken. Der direkt darauf
+    folgende streaming submit kann sich dann an einem frischen lme
+    als Floor ankern."""
+    printer, feeder = make_streaming_feeder()
+    motion_q = printer.lookup_object('motion_queuing')
+
+    feeder.reactor.now = 10.0
+    feeder._last_move_end_time = 0.0
+    feeder._current_move = None
+    lme_before = feeder._last_move_end_time
+
+    appends_before = len(motion_q.append_calls)
+    motion_q.trigger_flush(flush_time=10.0, step_gen_time=10.0)
+    own = own_trapq_appends(motion_q, feeder, appends_before)
+
+    assert len(own) == 2, "Anchor + streaming expected"
+    assert feeder._last_move_end_time > lme_before, (
+        "_last_move_end_time muss nach dem anchor vorruecken. "
+        "Vorher %.3f Nachher %.3f" % (lme_before,
+                                       feeder._last_move_end_time))
+    # Anchor + streaming chunk enden in naher Zukunft nach mcu_now.
+    # Anchor: 0.05mm @ feed_speed (~3ms duration). Streaming chunk:
+    # interrupt_chunk_mm=9mm @ feed_speed (~0.6s + accel/decel ~0.9s).
+    # Total <= 1.5s nach mcu_now+lead_time. lme darf NICHT mehr in
+    # far-future Toolhead-Time zeigen (step_gen_time = 10.0 hier,
+    # aber mit forced_t0-Clamp auf mcu_now+lead_time landet lme bei
+    # ~mcu_now + lead_time + 1s = 11.x — NICHT bei 58+s wie im
+    # Crash-Pattern).
+    assert feeder._last_move_end_time < 10.0 + 2.0, (
+        "_last_move_end_time nach Anchor+Streaming sollte nahe "
+        "mcu_now (forced_t0-Clamp greift). Erhalten: %.3f"
+        % feeder._last_move_end_time)

--- a/tests/test_cursor_freshness_before_submit.py
+++ b/tests/test_cursor_freshness_before_submit.py
@@ -1,35 +1,28 @@
-"""Cursor-Freshness-Contract — garantierte last_step_clock-Frische vor
-jedem streaming-Submit aus _on_mcu_flush.
+"""Cursor-Freshness-Contract (D2: Deferred-Streaming) — Pre-Anchor und
+Streaming-Submit auf zwei aufeinanderfolgende flush-callbacks aufteilen.
 
-Hardware-Beleg (2026-05-14 klippy_refactor_*_repro.log):
-
-  buffer_feeder: auto anchor fired (4× in der Idle-Phase mit hall_empty=True,
-                                    Watchdog-Fix aus PR #39 wirkt)
-  ... 8× buffer_metrics (idle continues)
-  Starting SD card print (position 0)
-  buffer_event[flush_submit]: anchor=58.698 move_active=False chunk=9.000
-  SET_KINEMATIC_POSITION pos=0.000,0.000,0.000 set_homed=xyz
+Hardware-Beleg V1 (Pre-D2-Version, klippy_refactor_*_repro.log):
+  Pre-Anchor fired (cursor_age=6.74s > 1.0s threshold),
+  Streaming-Submit folgte IM GLEICHEN flush-callback,
+  → beide queue_step-Bursts landen zusammen mit TMC-UART-Reads in
+    einem USB-Burst (Sent 83-97 alle bei T=1365910.806-.864).
+  → MCU empfaengt scheduled-step-clock bereits in der Vergangenheit
+    (lead_time=0.120s wird durch USB+MCU-CPU-Latenz aufgefressen).
   → MCU 'LLL_PLUS' shutdown: Timer too close
 
-Send-Queue-Beleg: queue_step oid=0 interval=332180349 count=1 add=0
-  (6.92s zwischen letztem Watchdog-Anchor und erstem Submit-Step). Mit
-  USB-Sende-Latenz + MCU-busy (TMC-UART-Storm in derselben Send-Sequenz)
-  landet der erste Step in der Vergangenheit relativ zur MCU-Clock zum
-  Receive-Zeitpunkt → Timer too close.
+Wurzel V2 (D2): Pre-Anchor + Streaming-Submit in einem flush-callback
+fuehrt zu USB-Burst-Race; selbst mit garantiert frischem _last_move_-
+end_time hat die MCU keinen Buffer um den Pre-Anchor-Step durchzu-
+schedulen bevor der Streaming-Step queued wird.
 
-Wurzel: _on_mcu_flush hat keinen Vertrag wie alt last_step_clock sein
-darf, bevor ein streaming-Submit ausgeloest wird. Watchdog feuert alle
-~10s als best-effort, schliesst aber das Race-Window nicht. Wenn
-streaming-Demand zwischen zwei Watchdog-Anchors landet (z.B. PRINT_START
-oeffnet das Idle-Suppression-Gate via state='printing'), schickt
-_flush_submit_streaming_chunk einen Move auf einen 7-10s alten Cursor.
-
-Fix-Vertrag (Phase 3 TDD): _flush_submit_streaming_chunk sichert vor
-JEDEM eigentlichen Streaming-Submit einen garantierten anchor-Step,
-wenn _last_move_end_time aelter als MIN_CURSOR_FRESHNESS_S ist und kein
-move_in_flight laeuft. Effekt: queue_step interval ist nach dem
-Pre-Anchor << 1s — keine Race-Anfaelligkeit mehr fuer Timer-too-close
-in dieser Wurzel-Klasse.
+Fix D2: Pre-Anchor submitten und SOFORT return (kein streaming-Submit
+in derselben flush-callback). Naechster flush-callback (~10-25ms
+spaeter via motion_queuing.flush_handler) findet _last_move_end_time
+frisch (vom Pre-Anchor), _move_in_flight() korrekt True solange
+Pre-Anchor laeuft, und faellt in den existierenden P7-66-Lookahead-
+Pfad zurueck (streaming abuttend an lme). MCU bekommt Pre-Anchor-
+Bytes und Streaming-Bytes in zwei separaten USB-Bursts mit
+ausreichendem Abstand — keine Race-Anfaelligkeit mehr.
 
 Komplementaer zu:
   - PR #39 (Watchdog feuert bei hall_empty=True im flush_callback-Pfad)
@@ -99,16 +92,18 @@ def own_trapq_appends(motion_q, feeder, before_count):
 # ---------------------------------------------------------------------------
 
 
-def test_freshness_anchor_fires_when_cursor_stale_and_no_move_in_flight():
-    """Wurzel-Fall: _last_move_end_time ist >MIN_CURSOR_FRESHNESS_S
-    alt, kein move in flight, streaming demand vorhanden
-    (hall_empty=True). Erwartung: ZWEI trapq_append-Calls — zuerst
-    ein Anchor-Step (Cursor-Refresh, 0.05mm), dann der eigentliche
-    streaming chunk (interrupt_chunk_mm).
+def test_freshness_anchor_fires_alone_when_cursor_stale_d2_deferred():
+    """D2 Wurzel-Fall: bei stale cursor submittet _flush_submit_-
+    streaming_chunk nur den Pre-Anchor und KEHRT ZURUECK (kein
+    streaming-Submit in derselben flush-callback). Der streaming-
+    Submit wird auf den NAECHSTEN flush-callback verschoben — so
+    landen die queue_step-Bytes in zwei separaten USB-Bursts mit
+    ausreichendem MCU-Verarbeitungs-Buffer dazwischen.
 
-    Pre-Fix: nur EIN append (streaming submit mit interval > 1s).
-    Hardware-Crash: queue_step interval=332M Ticks (6.92s) → Timer
-    too close beim ersten Submit nach PRINT_START.
+    Pre-D2 (PR #40 V1): 2 appends (Anchor + Streaming sofort)
+    -> USB-Burst-Race -> Timer too close.
+
+    D2: 1 append (nur Anchor diese flush-callback).
     """
     printer, feeder = make_streaming_feeder()
     motion_q = printer.lookup_object('motion_queuing')
@@ -122,23 +117,67 @@ def test_freshness_anchor_fires_when_cursor_stale_and_no_move_in_flight():
     motion_q.trigger_flush(flush_time=10.0, step_gen_time=10.0)
     own = own_trapq_appends(motion_q, feeder, appends_before)
 
-    assert len(own) == 2, (
-        "Erwartung: Cursor-Freshness-Anchor zuerst, dann streaming "
-        "submit (2 own_trapq appends). Erhalten: %d" % len(own))
-    # Erstes append = Anchor (0.05mm, kleine Distanz im accel/cruise/decel)
+    assert len(own) == 1, (
+        "D2: Pre-Anchor allein in dieser flush-callback. "
+        "Streaming-Submit erst beim naechsten flush-callback. "
+        "Erhalten: %d appends" % len(own))
+    # Sole append ist der Anchor (kleine Distanz)
     anchor_call = own[0]
-    streaming_call = own[1]
-    # axes_r ist Argument 9 in trapq_append signature (x-Komponente):
-    # (trapq, t0, accel_time, cruise_time, decel_time,
-    #  start_pos_x, _, _, axes_r_x, _, _, start_v, cruise_v, accel)
-    # Anchor sollte deutlich kleinere Bewegungszeit haben als Streaming.
-    anchor_total_time = anchor_call[2] + anchor_call[3] + anchor_call[4]
-    streaming_total_time = (streaming_call[2] + streaming_call[3]
-                            + streaming_call[4])
-    assert anchor_total_time < streaming_total_time, (
-        "Anchor-Move soll kuerzer sein als streaming chunk. "
-        "Anchor=%.4fs Streaming=%.4fs" % (anchor_total_time,
-                                          streaming_total_time))
+    # Anchor-Distanz aus Trapezoid-Profil rekonstruieren
+    accel_time = anchor_call[2]
+    cruise_time = anchor_call[3]
+    decel_time = anchor_call[4]
+    cruise_v = anchor_call[12]
+    total_dist = (cruise_v * cruise_time
+                  + 0.5 * cruise_v * (accel_time + decel_time))
+    assert total_dist == pytest.approx(ANCHOR_NUDGE_MM, abs=0.001), (
+        "Sole append in D2-deferred ist der Anchor. "
+        "Erwartete Distanz: %.3fmm, erhalten: %.4fmm"
+        % (ANCHOR_NUDGE_MM, total_dist))
+
+
+def test_streaming_follows_pre_anchor_on_next_flush_callback():
+    """D2 Vertrag: nach dem Pre-Anchor (1. flush-callback) erfolgt
+    der streaming-Submit beim NAECHSTEN flush-callback. Da der
+    Pre-Anchor _last_move_end_time auf mcu_now+lead_time gesetzt
+    hat, ist der naechste flush-callback im move_in_flight=True
+    Pfad (P7-66 Lookahead-Submit, abuttend an lme)."""
+    printer, feeder = make_streaming_feeder()
+    motion_q = printer.lookup_object('motion_queuing')
+
+    # 1. flush-callback: stale cursor
+    feeder.reactor.now = 10.0
+    feeder._last_move_end_time = 0.0
+    feeder._current_move = None
+
+    appends_before = len(motion_q.append_calls)
+    motion_q.trigger_flush(flush_time=10.0, step_gen_time=10.0)
+    own_first = own_trapq_appends(motion_q, feeder, appends_before)
+    assert len(own_first) == 1, "1. flush: nur Pre-Anchor"
+
+    # Pre-Anchor hat lme auf naehe mcu_now gesetzt:
+    assert feeder._last_move_end_time > 10.0, (
+        "Pre-Anchor muss _last_move_end_time setzen. "
+        "Erhalten: %.3f" % feeder._last_move_end_time)
+    pre_anchor_end = feeder._last_move_end_time
+
+    # 2. flush-callback (10ms spaeter): pre-anchor in flight,
+    # remaining = lme - step_gen_time < lead_time -> Lookahead
+    # streaming-submit abuttend an lme.
+    appends_before = len(motion_q.append_calls)
+    # step_gen_time so dass remaining = pre_anchor_end - sg klein
+    motion_q.trigger_flush(flush_time=10.01,
+                           step_gen_time=pre_anchor_end - 0.05)
+    own_second = own_trapq_appends(motion_q, feeder, appends_before)
+    assert len(own_second) == 1, (
+        "2. flush: streaming-Submit nach Pre-Anchor. "
+        "Erhalten: %d appends" % len(own_second))
+    # Streaming-Submit muss abuttend an pre_anchor_end starten
+    streaming_t0 = own_second[0][1]
+    assert streaming_t0 == pytest.approx(pre_anchor_end, abs=0.001), (
+        "Streaming-Submit muss abuttend an Pre-Anchor-Ende starten "
+        "(P7-66 Lookahead). t0=%.3f erwartet=%.3f"
+        % (streaming_t0, pre_anchor_end))
 
 
 def test_no_freshness_anchor_when_cursor_fresh():
@@ -224,9 +263,8 @@ def test_no_freshness_anchor_when_target_speed_zero():
 
 def test_freshness_anchor_distance_is_anchor_nudge_mm():
     """Der Pre-Anchor verwendet ANCHOR_NUDGE_MM (0.05mm) — minimal
-    physisch spuerbar, aber genug fuer cursor refresh. axes_r_x +
-    Trapezoid-Profile lassen sich daraus rekonstruieren: distance =
-    0.5*cruise_v*(accel_time+decel_time) + cruise_v*cruise_time."""
+    physisch spuerbar, aber genug fuer cursor refresh. Distanz aus
+    Trapezoid-Profil rekonstruieren."""
     printer, feeder = make_streaming_feeder()
     motion_q = printer.lookup_object('motion_queuing')
 
@@ -238,7 +276,8 @@ def test_freshness_anchor_distance_is_anchor_nudge_mm():
     motion_q.trigger_flush(flush_time=10.0, step_gen_time=10.0)
     own = own_trapq_appends(motion_q, feeder, appends_before)
 
-    assert len(own) >= 1, "Anchor muss gefeuert haben"
+    # D2: 1 append in dieser flush-callback (nur Pre-Anchor)
+    assert len(own) == 1, "Anchor muss gefeuert haben (D2: sole append)"
     anchor_call = own[0]
     # Trapq-Append-Signatur, accel_time=arg[2], cruise_time=arg[3],
     # decel_time=arg[4], cruise_v=arg[12], accel=arg[13].
@@ -257,9 +296,7 @@ def test_freshness_anchor_distance_is_anchor_nudge_mm():
 
 def test_freshness_anchor_direction_positive_in_normal_demand():
     """Im normalen Demand-Pfad (kein hall_overflow): Anchor laeuft
-    in feed-direction (positiv). hall_overflow=True ist ein
-    separater Pfad — der flush-callback hat dafuer einen
-    Hall1Context.SUBMIT_MOVE early-return weiter oben."""
+    in feed-direction (positiv)."""
     printer, feeder = make_streaming_feeder()
     motion_q = printer.lookup_object('motion_queuing')
     # Default: hall_overflow=False bereits via make_streaming_feeder
@@ -272,7 +309,8 @@ def test_freshness_anchor_direction_positive_in_normal_demand():
     motion_q.trigger_flush(flush_time=10.0, step_gen_time=10.0)
     own = own_trapq_appends(motion_q, feeder, appends_before)
 
-    assert len(own) == 2, "Anchor + streaming expected"
+    # D2: 1 append in dieser flush-callback (nur Pre-Anchor)
+    assert len(own) == 1, "D2: Pre-Anchor allein"
     anchor_call = own[0]
     # direction (axes_r_x) = Argument 8 (0-indexed) in trapq_append:
     # (trapq, t0, accel_time, cruise_time, decel_time,
@@ -300,20 +338,17 @@ def test_freshness_anchor_advances_last_move_end_time():
     motion_q.trigger_flush(flush_time=10.0, step_gen_time=10.0)
     own = own_trapq_appends(motion_q, feeder, appends_before)
 
-    assert len(own) == 2, "Anchor + streaming expected"
+    # D2: nur Pre-Anchor in dieser flush-callback. Streaming kommt
+    # erst beim naechsten flush-callback.
+    assert len(own) == 1, "D2: nur Pre-Anchor"
     assert feeder._last_move_end_time > lme_before, (
         "_last_move_end_time muss nach dem anchor vorruecken. "
         "Vorher %.3f Nachher %.3f" % (lme_before,
                                        feeder._last_move_end_time))
-    # Anchor + streaming chunk enden in naher Zukunft nach mcu_now.
-    # Anchor: 0.05mm @ feed_speed (~3ms duration). Streaming chunk:
-    # interrupt_chunk_mm=9mm @ feed_speed (~0.6s + accel/decel ~0.9s).
-    # Total <= 1.5s nach mcu_now+lead_time. lme darf NICHT mehr in
-    # far-future Toolhead-Time zeigen (step_gen_time = 10.0 hier,
-    # aber mit forced_t0-Clamp auf mcu_now+lead_time landet lme bei
-    # ~mcu_now + lead_time + 1s = 11.x — NICHT bei 58+s wie im
-    # Crash-Pattern).
-    assert feeder._last_move_end_time < 10.0 + 2.0, (
-        "_last_move_end_time nach Anchor+Streaming sollte nahe "
-        "mcu_now (forced_t0-Clamp greift). Erhalten: %.3f"
-        % feeder._last_move_end_time)
+    # Pre-Anchor: 0.05mm @ feed_speed (~3ms duration). forced_t0
+    # wird intern auf mcu_now+lead_time geclampt. lme nach Anchor
+    # = mcu_now+lead_time+anchor_dur ≈ mcu_now + 0.125s.
+    assert feeder._last_move_end_time < 10.0 + 0.5, (
+        "_last_move_end_time nach Pre-Anchor sollte nahe mcu_now "
+        "(forced_t0-Clamp greift, Anchor ist 3-5ms). "
+        "Erhalten: %.3f" % feeder._last_move_end_time)

--- a/tests/test_debug_event_logging.py
+++ b/tests/test_debug_event_logging.py
@@ -47,6 +47,10 @@ def test_debug_event_logging_emits_flush_submit_when_enabled(caplog):
     )
     set_sensor_active(feeder, 'hall_empty', True)
     feeder.reactor.now = 5.0
+    # D2 Cursor-Freshness-Contract: damit dieser Test den
+    # flush_submit-Pfad sieht (nicht den deferred-anchor-Pfad),
+    # _last_move_end_time frisch setzen.
+    feeder._last_move_end_time = 4.9
 
     with caplog.at_level(logging.INFO, logger=""):
         feeder._on_mcu_flush(flush_time=5.0, step_gen_time=5.05)

--- a/tests/test_flush_callback_bang_bang.py
+++ b/tests/test_flush_callback_bang_bang.py
@@ -94,6 +94,12 @@ def test_flush_submits_when_hall3_active_and_state_auto():
     # mcu_now + 2.0s, so an artificial reactor.now=0 + step_gen_time=
     # 5.05 would now (correctly) trip the far-future clamp.
     feeder.reactor.now = 5.0
+    # D2 Cursor-Freshness-Contract: damit dieser Test den
+    # primaeren streaming-submit-Pfad prueft (nicht den deferred-
+    # anchor-Pfad bei stale cursor), _last_move_end_time frisch
+    # setzen. Cursor-Freshness ist separat in
+    # test_cursor_freshness_before_submit.py getestet.
+    feeder._last_move_end_time = 4.9
 
     appends_before = len(motion_q.append_calls)
     motion_q.trigger_flush(flush_time=5.0, step_gen_time=5.05)

--- a/tests/test_idle_watchdog_anchor.py
+++ b/tests/test_idle_watchdog_anchor.py
@@ -298,3 +298,103 @@ def test_anchor_after_two_full_windows_fires_again(monkeypatch):
     assert len(calls) == 2, (
         "After a full idle_anchor_gap elapses since the previous "
         "anchor, the watchdog must re-fire.")
+
+
+# ---------------------------------------------------------------------------
+# Issue #31 Refactor-Port Regression: Watchdog vs. hall_empty + flush_callback
+# ---------------------------------------------------------------------------
+#
+# Hotfix 10 (Hardware 2026-05-14, klippy.log Z.363): MCU 'LLL_PLUS' shutdown
+# "Timer too close" beim ersten Druckstart nach Klipper-Idle (gap=257.7s).
+#
+# Wurzel: Der P7-75 Sub-Gate `not self.hall_empty` blockierte den Watchdog
+# auch im flush-callback-bang-bang-Pfad (use_flush_callback_bang_bang=True).
+# Dort ist `_bang_bang_tick` ein No-Op — der Race vor dem das Gate
+# schuetzen sollte (Bang-Bang-Feed-Request vs. Watchdog-Anchor) existiert
+# nur im klassischen Reactor-Tick-Pfad. Im flush-callback-Pfad ist der
+# Watchdog die EINZIGE Schutzschicht gegen stale last_step_clock waehrend
+# Klipper-Idle (kein motion_queuing-Callback ohne Steps).
+#
+# Fix: hall_empty-Gate konditional an use_flush_callback_bang_bang=False
+# binden. Mit flush_callback_bang_bang=True (= C-cont Streaming-Modus)
+# feuert der Watchdog auch bei hall_empty=True.
+#
+# Status: Im Refactor (Commit 02e9b33) wurde nur Teil 2 von Hotfix 10
+# portiert (Idle-Suppression in _on_mcu_flush). Teil 1 (Watchdog-Gate-
+# Anpassung) fehlt — diese Tests sind die TDD-Regression.
+
+
+def test_watchdog_fires_in_auto_with_hall_empty_when_flush_callback_bangbang(
+        monkeypatch):
+    """Hotfix 10 (Issue #31 Refactor-Port-Regression):
+    Im flush-callback-bang-bang-Pfad (use_flush_callback_bang_bang=True)
+    muss der Watchdog auch bei hall_empty=True feuern.
+
+    Pre-condition fuer den realen Hardware-Crash:
+      - state=AUTO, kein Druck aktiv (print_stats=standby)
+      - hall_empty=True (Buffer-Arm in entrance-Position, normales Idle)
+      - use_flush_callback_bang_bang=True (C-cont Streaming-Modus)
+      - _continuous_feed=False (Bang-Bang nicht aktiv)
+      - gap > idle_anchor_gap
+
+    Ohne Fix bleibt last_step_clock stale → erster Submit nach PRINT_START
+    crasht mit Timer-too-close. Mit Fix feuert der Watchdog regelmaessig
+    den 0.05mm-Micro-Anchor und haelt den Cursor frisch.
+
+    Hardware-Beleg: klippy_refactor_timer_too_close.log Z.3086 (clock=
+    4052274463, 0 'auto anchor fired' Events in der gesamten Idle-Phase).
+    """
+    _, feeder = make_idle_feeder(
+        values={'use_flush_callback_bang_bang': True})
+    feeder._state = buffer_feeder.STATE_AUTO
+    # Bang-Bang muss quiescent sein (sonst greift der continuous_feed-Gate).
+    feeder._continuous_feed = False
+    # hall_empty=True simuliert Filament-im-Buffer-Idle: Arm haengt in
+    # entrance-Position.
+    set_sensor_active(feeder, 'hall_empty', True)
+    set_sensor_active(feeder, 'hall_full', False)
+    set_sensor_active(feeder, 'hall_overflow', False)
+
+    calls = count_anchor_calls(monkeypatch, feeder)
+    feeder.reactor.now = 20.0
+    feeder._last_move_end_time = 0.0
+    feeder._main_tick(eventtime=20.0)
+
+    assert len(calls) == 1, (
+        "Hotfix 10: Watchdog MUSS in STATE_AUTO mit hall_empty=True "
+        "feuern, wenn use_flush_callback_bang_bang=True. Ohne diesen "
+        "Anchor altert last_step_clock waehrend Klipper-Idle und der "
+        "erste Submit nach PRINT_START crasht mit Timer-too-close.")
+
+
+def test_watchdog_still_blocks_in_auto_with_hall_empty_when_classic_bangbang(
+        monkeypatch):
+    """Regression P7-75 klassischer Pfad: bei use_flush_callback_bang_-
+    bang=False bleibt das hall_empty-Gate aktiv.
+
+    Hier laeuft _bang_bang_tick im Reactor-Tick als echter Submitter.
+    Ein Watchdog-Anchor parallel dazu wuerde mit dem Bang-Bang-Feed-
+    Request racen — genau der Race vor dem P7-75 urspruenglich
+    geschuetzt hatte. Das Gate muss in diesem Pfad weiter blocken.
+    """
+    _, feeder = make_idle_feeder(
+        values={'use_flush_callback_bang_bang': False})
+    feeder._state = buffer_feeder.STATE_AUTO
+    feeder._continuous_feed = False
+    set_sensor_active(feeder, 'hall_empty', True)
+    set_sensor_active(feeder, 'hall_full', False)
+    set_sensor_active(feeder, 'hall_overflow', False)
+    # Bang-bang-tick patchen um Observation eng zu halten (existierendes
+    # Pattern in test_state_auto_with_active_bangbang_does_not_fire).
+    monkeypatch.setattr(feeder, "_bang_bang_tick", lambda et: None)
+
+    calls = count_anchor_calls(monkeypatch, feeder)
+    feeder.reactor.now = 20.0
+    feeder._last_move_end_time = 0.0
+    feeder._main_tick(eventtime=20.0)
+
+    assert calls == [], (
+        "P7-75 klassischer Reactor-Tick-Pfad: hall_empty-Gate muss "
+        "Watchdog weiter blocken, wenn use_flush_callback_bang_bang="
+        "False. Sonst race zwischen Watchdog-Anchor und Bang-Bang-"
+        "Feed-Request im _bang_bang_tick.")

--- a/tests/test_streaming_pipeline_auto.py
+++ b/tests/test_streaming_pipeline_auto.py
@@ -711,6 +711,10 @@ def test_streaming_then_halt_motion_clears_all_pending():
     # motion-Cleanup-Path zu testen (Sub-Chunk-Stream-Cleanup bleibt
     # relevant fuer Legacy-Pfade ausserhalb Continuous-Streaming).
     feeder.reactor.now = 5.00
+    # D2 Cursor-Freshness-Contract: damit der flush den primaeren
+    # streaming-submit-Pfad nimmt (nicht den deferred-anchor-Pfad
+    # bei stale cursor), _last_move_end_time frisch setzen.
+    feeder._last_move_end_time = 4.9
     motion_q.trigger_flush(flush_time=5.00, step_gen_time=5.05)
     assert feeder._continuous_feed is True
     feeder._pending_remaining_mm = 27.0  # Kuenstlich seeden

--- a/tests/test_streaming_pipeline_auto.py
+++ b/tests/test_streaming_pipeline_auto.py
@@ -482,6 +482,12 @@ def test_interrupt_cap_splits_large_chunk():
     set_sensor_active(feeder, 'hall_empty', True)
 
     feeder.reactor.now = 5.0
+    # Cursor frisch setzen so dass Cursor-Freshness-Anchor nicht
+    # vor dem sub-chunk-Split-Test triggert (vgl. test_cursor_-
+    # freshness_before_submit.py; default lme=0 wuerde age=5s
+    # ergeben und einen pre-anchor erzwingen, was diesen Test
+    # auf splitting-spezifisches Verhalten verfaelscht).
+    feeder._last_move_end_time = 4.9
     appends_before = len(motion_q.append_calls)
     motion_q.trigger_flush(flush_time=5.0, step_gen_time=5.05)
 


### PR DESCRIPTION
> ⚠️ **HW-Test ausstehend.** Dieser PR basiert auf solider Code-Pfad-Analyse + Hardware-Log-Evidenz aus zwei vorherigen Crash-Runs, der Fix wurde aber noch nicht auf dem Drucker validiert. PR ist offen zur Diskussion + ggf. parallel zum HW-Test reviewbar.

## Problem

Hardware-Beleg (`refactor/cleanup-all-phases` HEAD `97e97e7` + PR #39 mit `hall_empty`-Watchdog-Bypass):

```
buffer_feeder: auto anchor fired (4×)             ← Watchdog-Fix aus PR #39 wirkt
... 8× buffer_metrics (idle, hall_empty=True)
Starting SD card print (position 0)               ← print_stats.state = 'printing'
buffer_event[flush_submit]: anchor=58.698 move_active=False chunk=9.000
SET_KINEMATIC_POSITION pos=0.000,0.000,0.000 set_homed=xyz
→ MCU 'LLL_PLUS' shutdown: Timer too close
```

**Send-Queue (LLL_PLUS Sent 82):**
```
queue_step oid=0 interval=332180349 count=1 add=0
```
`interval=332180349` Ticks @ 48 MHz = **6.92 Sekunden** zwischen letztem Watchdog-Anchor-Step und erstem Submit-Step.

## Wurzel

`_on_mcu_flush` hat keinen Vertrag wie alt `last_step_clock` (MCU-Seite) sein darf, bevor ein streaming-Submit ausgelöst wird. Watchdog feuert alle ~10s als best-effort, schließt aber das Race-Window nicht:

- `state='printing'` wird beim "Starting SD card print" sofort gesetzt
- Idle-Suppression-Gate öffnet (`_is_active_print_state()=True`)
- Erster streaming-Submit kann zwischen zwei Watchdog-Fires landen → Cursor 0-10s alt
- `queue_step interval = (mcu_now + lead_time) - last_step_clock` wird entsprechend groß
- Mit USB-Sende-Latenz + MCU-busy (TMC-UART-Storm in selber Send-Sequenz) kann der erste Step relativ zur MCU-Clock zum Receive-Zeitpunkt in der **Vergangenheit** landen → Timer too close

## Fix (Cursor-Freshness-Contract)

In `_flush_submit_streaming_chunk` vor dem finalen `_submit_move`:

```python
if not move_active:
    mcu_now = self.stepper.get_mcu().estimated_print_time(
        self.reactor.monotonic())
    cursor_age = mcu_now - self._last_move_end_time
    if cursor_age > MIN_CURSOR_FRESHNESS_S:  # 1.0s
        anchor_dir = -1.0 if self.hall_overflow else 1.0
        self._submit_move(
            anchor_dir * ANCHOR_NUDGE_MM,
            self.feed_speed,
            forced_t0=step_gen_time + self.lead_time)
```

**Effekt strukturell:**
- Vor jedem streaming-Submit mit stale cursor: garantierter Pre-Anchor (0.05mm)
- `forced_t0` wird intern auf `mcu_now + lead_time` geclampt — Anchor sicher in naher Zukunft
- Nach Pre-Anchor: `last_step_clock` ≤ `lead_time` (~120ms) alt
- Streaming-Submit folgender `queue_step interval` << 1s — **race-frei** unter jeder USB-Latenz

## Komplementäre Architektur

Drei orthogonale Schutzschichten gegen unterschiedliche Timer-too-close-Klassen:

| Klasse | Wurzel | Fix |
|---|---|---|
| A: Idle-Stale-Cursor | `last_step_clock` altert in Klipper-Idle, kein Watchdog | **PR #39** |
| B: Stale-Future-Floors | `_last_move_end_time`/`_last_enable_schedule_time` weit voraus überschreiben `forced_t0` | **`97e97e7`** |
| C: Pre-Submit-Race | `last_step_clock`-Alter zwischen Anchor und erstem streaming-Submit | **dieser PR** |

Keine Schicht ist redundant — jede deckt eine andere Failure-Klasse ab. Defense-in-depth.

## Begleitende Änderungen

- **Neue Konstante** `MIN_CURSOR_FRESHNESS_S = 1.0` in `_buffer_common.py` (mit ausführlichem docstring zur Begründung)
- **`klipper_extras/buffer_feeder.py`** — ~20 LOC Cursor-Freshness-Block in `_flush_submit_streaming_chunk`
- **`tests/test_cursor_freshness_before_submit.py`** — neu, 7 Tests
- **`tests/test_streaming_pipeline_auto.py`** — 1 Test-Fixture-Anpassung (`test_interrupt_cap_splits_large_chunk` setzt jetzt `_last_move_end_time = 4.9` damit Pre-Anchor nicht den Sub-Chunk-Splitting-Test verfälscht)

## Tests (TDD Phase 3, Iron Law eingehalten)

**RED:** 4 Tests fail vor Fix:
- `test_freshness_anchor_fires_when_cursor_stale_and_no_move_in_flight`
- `test_freshness_anchor_distance_is_anchor_nudge_mm`
- `test_freshness_anchor_direction_positive_in_normal_demand`
- `test_freshness_anchor_advances_last_move_end_time`

**GREEN:** nach Fix alle 7 Tests passing (3 weitere für Negative-Cases):
- `test_no_freshness_anchor_when_cursor_fresh`
- `test_no_freshness_anchor_when_move_in_flight`
- `test_no_freshness_anchor_when_target_speed_zero`

**Full-Suite:** 405 → 412 passed, 0 echte Regressionen.

## Status & Abhängigkeiten

- **HW-Test:** ⚠️ **AUSSTEHEND.** Wurzel + Fix sind durch Hardware-Log + Send-Queue-Math + Code-Pfad-Analyse belegt, aber dieser konkrete Fix-Code wurde noch nicht auf dem Drucker validiert.
- **Pre-Commitment (Iron Law):** falls HW-Test den Crash trotz Combined-Fix (#39 + `97e97e7` + dieser PR) reproduziert, **kein weiterer Quick-Fix** — Architektur-Diskussion mit dir gewünscht.
- **Abhängigkeit:** baut auf PR #39 (`hotfix-issue31-watchdog-refactor-port`) auf, das wiederum auf `97e97e7` rebased ist.

Folge-Update nach HW-Test im Kommentar.