### PR TITLE
fix(buffer_feeder): HALL3-Demand-Semantik — Wurzel-C-Praevention (HW-Test 3x ohne Crash, End-to-End noch ausstehend wegen Drucker-Hardware-Issue)

### DIFF
--- a/klipper_extras/buffer_feeder.py
+++ b/klipper_extras/buffer_feeder.py
@@ -1120,13 +1120,42 @@ class BufferFeeder:
                     _print_active = False
                     _p778_override = True
 
+            # Hotfix 10 (Issue #31 Refactor-Port, Hardware 2026-05-14
+            # klippy.log: MCU 'LLL_PLUS' shutdown "Timer too close" beim
+            # ersten Druckstart nach Klipper-Idle, 0 Watchdog-Anchor-
+            # Fires in der gesamten Idle-Phase).
+            #
+            # P7-75 Original-Bedingung `not self.hall_empty` schuetzt
+            # vor Race mit Bang-Bang-Feed-Request. Diese Race existiert
+            # NUR im Reactor-Tick-Bang-Bang-Pfad (use_flush_callback_-
+            # bang_bang=False). Bei use_flush_callback_bang_bang=True
+            # ist _bang_bang_tick ein No-Op, Bang-Bang feuert NUR via
+            # _on_mcu_flush, der waehrend Klipper-Idle gar nicht
+            # gerufen wird (keine motion_queuing-Aktivitaet). Resultat:
+            # hall_empty=True + Klipper-Idle + flush_callback-Pfad ->
+            # kein Submit -> last_step_clock altert -> Timer too close
+            # beim ersten Print-Start-Submit nach > CLOCK_DIFF_MAX
+            # (~16.78s @ 48MHz).
+            #
+            # Fix: hall_empty-Gate nur aktiv wenn use_flush_callback_-
+            # bang_bang=False (klassischer Reactor-Tick-Pfad). Im
+            # flush-callback-Pfad muss Watchdog auch bei hall_empty
+            # feuern. Andere Sub-Gates (_continuous_feed, hall_full,
+            # _needs_overflow_prime) bleiben unveraendert — kein Race
+            # mit aktivem Stream, kein Forward-Feed in vollen Buffer.
+            #
+            # Siehe tests/test_idle_watchdog_anchor.py:
+            #   test_watchdog_fires_in_auto_with_hall_empty_when_flush_callback_bangbang
+            #   test_watchdog_still_blocks_in_auto_with_hall_empty_when_classic_bangbang
+            hall_empty_block = (self.hall_empty
+                                and not self.use_flush_callback_bang_bang)
             if (self._state in (STATE_IDLE, STATE_AUTO)
                     and not self._stepper_synced_to
                     and not self._pending_disable
                     and not self._move_in_flight()
                     and self._pending_remaining_mm == 0.0
                     and not self._continuous_feed
-                    and not self.hall_empty
+                    and not hall_empty_block
                     and not self.hall_full
                     and not self._needs_overflow_prime
                     and not _print_active):  # P7-77 A + P7-78 Override

--- a/klipper_extras/buffer_feeder.py
+++ b/klipper_extras/buffer_feeder.py
@@ -1590,14 +1590,30 @@ class BufferFeeder:
         Deshalb skaliert HALL3 jetzt mit dem realen Extruder-Verbrauch
         und nutzt nur noch einen sanften MIN_FLOOR als Unterkante.
 
+        Wurzel-C-Praevention (γ, 2026-05-14): HALL3=True hat zwei
+        Bedeutungen:
+          1. Aktiver Print: Extruder zieht Filament -> Arm hochgezogen
+             -> echter Demand fuer Refill
+          2. Idle / Pre-Print-Phase: Arm liegt natuerlich oben durch
+             fehlende Zugkraft -> KEIN Demand, Buffer ist in Ruhe
+        Vor Fix: beide Faelle gleich -> HALL3-only-demand triggert
+        streaming-submit beim Druckstart -> Race mit PRINT_START
+        Macro (SET_KINEMATIC_POSITION + TMC-UART-Burst) -> MCU 'LLL_-
+        PLUS' shutdown: Timer too close (vier HW-Test-Belege).
+        Fix: HALL3 nur als Demand interpretieren wenn ext_vel > 0
+        (Extruder zieht aktiv). Idle-HALL3 -> 0.
+
           HALL1 (overflow)  -> 0.0
           HALL2 (full)      -> 0.0
           HALL3 (empty):
-            tracker not_ready / vel < floor -> floor
-            sonst                           -> min(max(vel * 1.5, floor), feed_speed)
+            ext_vel <= 0                    -> 0.0  (γ: kein idle-demand)
+            0 < ext_vel < floor             -> floor
+            ext_vel >= floor                -> min(max(vel * 1.5, floor),
+                                                   feed_speed)
           Zwischenzone:
             tracker not_ready / vel < floor -> 0.0
-            sonst                           -> min(vel * feed_speed_gain, feed_speed)
+            sonst                           -> min(vel * feed_speed_gain,
+                                                   feed_speed)
         """
         floor = self.min_feed_floor
         floor_epsilon = 1e-6
@@ -1610,7 +1626,14 @@ class BufferFeeder:
         vel_ready = self.velocity_tracker.is_ready()
         extruder_vel = self.velocity_tracker.get_velocity() if vel_ready else 0.0
         if self.hall_empty:
-            if not vel_ready or extruder_vel < floor - floor_epsilon:
+            # Wurzel-C-Praevention γ: HALL3 ohne aktiven Extruder ist
+            # kein Demand-Signal sondern Idle-Resting-Position.
+            # Damit triggert HALL3 alleine NICHT mehr den streaming-
+            # submit beim Druckstart (vor Heat-Up-/QGL-Phase).
+            if not vel_ready or extruder_vel <= floor_epsilon:
+                self._modulator_feeding = False
+                return 0.0
+            if extruder_vel < floor - floor_epsilon:
                 self._modulator_feeding = True
                 return floor
             self._modulator_feeding = True

--- a/tests/test_c_cont_streaming.py
+++ b/tests/test_c_cont_streaming.py
@@ -254,9 +254,14 @@ def test_c_cont_hotfix4_stalled_toolhead_no_submit_in_full_buffer(monkeypatch):
 
 
 def test_c_cont_hotfix4_stalled_but_hall_empty_still_fills(monkeypatch):
-    """Hotfix5: HALL3 active + Toolhead stalled -> foerdere TROTZDEM
-    (Buffer wirklich leer). Mit Soft-Throttle jetzt nur MIN_FLOOR
-    statt vollem feed_speed."""
+    """SUPERSEDED durch Wurzel-C-Praevention γ (2026-05-14):
+    HALL3 ohne ext_vel ist KEIN Demand-Signal mehr, sondern Idle-
+    Resting-Position. Old behavior (force-fill mit MIN_FLOOR) hat
+    den Race mit PRINT_START Macro getriggert -> Timer too close.
+
+    Hotfix4-Original-Annahme war: HALL3 immer = demand. γ-Befund:
+    nur HALL3+aktiver Extruder = demand. Idle-HALL3 -> 0.
+    """
     printer, feeder = make_c_cont_feeder(monkeypatch)
     set_sensor_active(feeder, 'hall_empty', True)
     set_sensor_active(feeder, 'hall_full', False)
@@ -268,8 +273,8 @@ def test_c_cont_hotfix4_stalled_but_hall_empty_still_fills(monkeypatch):
         feeder.velocity_tracker.tick(t)
         t += 0.025
     assert feeder.velocity_tracker.get_velocity() == 0.0
-    # HALL3 dominiert weiterhin, aber nur mit MIN_FLOOR.
-    assert feeder._compute_target_feed_speed() == pytest.approx(15.0, abs=0.1)
+    # γ: HALL3 + ext_vel=0 -> KEIN demand (Idle-Resting).
+    assert feeder._compute_target_feed_speed() == 0.0
 
 
 def test_c_cont_hotfix4_not_ready_no_submit_in_full(monkeypatch):
@@ -284,13 +289,22 @@ def test_c_cont_hotfix4_not_ready_no_submit_in_full(monkeypatch):
 
 
 def test_c_cont_hotfix4_not_ready_but_hall_empty_uses_fallback(monkeypatch):
-    """Tracker not_ready + HALL3 -> MIN_FLOOR fuer sanften Initial-Fill."""
+    """SUPERSEDED durch Wurzel-C-Praevention γ (2026-05-14):
+    Tracker not_ready + HALL3 -> KEIN demand mehr.
+
+    Hotfix4 hatte MIN_FLOOR auch bei not_ready zurueckgegeben, um
+    "sanften Initial-Fill" zu ermoeglichen. γ-Befund: das triggert
+    den Race mit PRINT_START Macro beim ersten Druckstart nach
+    Klipper-Boot/Idle. Mit γ wartet buffer_feeder bis tatsaechlich
+    extruder-Verbrauch vorhanden ist (post-Heating).
+    """
     printer, feeder = make_c_cont_feeder(monkeypatch)
     set_sensor_active(feeder, 'hall_empty', True)
     set_sensor_active(feeder, 'hall_full', False)
     set_sensor_active(feeder, 'hall_overflow', False)
     assert not feeder.velocity_tracker.is_ready()
-    assert feeder._compute_target_feed_speed() == pytest.approx(15.0, abs=0.1)
+    # γ: not_ready + HALL3 -> 0 (war frueher MIN_FLOOR)
+    assert feeder._compute_target_feed_speed() == 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -586,16 +600,20 @@ def test_c_cont_idle_suppresses_auto_stream(monkeypatch):
 
 
 def test_c_cont_active_print_allows_auto_stream(monkeypatch):
-    """Der Idle-Schutz darf den echten Print-Pfad nicht blockieren."""
+    """Der Idle-Schutz darf den echten Print-Pfad nicht blockieren.
+    γ-Wurzel-C-Praevention: Tracker muss aktive ext_vel >0 zeigen,
+    sonst gilt HALL3 nicht als demand."""
     printer, feeder = make_c_cont_feeder(monkeypatch, print_state='printing')
     feeder._state = buffer_feeder.STATE_AUTO
     set_sensor_active(feeder, 'hall_empty', True)
+    _populate_tracker_to_ready(feeder, velocity=15.0)
     submits = _capture_submits(feeder, monkeypatch)
     feeder._last_move_end_time = 0.0
     feeder._pending_remaining_mm = 0.0
     feeder._on_mcu_flush(flush_time=10.0, step_gen_time=10.0)
     assert len(submits) == 1
-    assert submits[0]['speed'] == pytest.approx(15.0, abs=0.1)
+    # Soft-Throttle: ext_vel=15 -> 15*1.5 = 22.5
+    assert submits[0]['speed'] == pytest.approx(22.5, abs=0.1)
 
 
 # ===========================================================================

--- a/tests/test_debug_event_logging.py
+++ b/tests/test_debug_event_logging.py
@@ -15,6 +15,14 @@ def make_feeder(values=None, state=None, print_state="printing"):
     set_sensor_active(feeder, 'hall_overflow', False)
     set_sensor_active(feeder, 'hall_full', False)
     set_sensor_active(feeder, 'hall_empty', False)
+    # Wurzel-C-Praevention γ: Tracker mit ext_vel>0 vorbefuellen
+    # damit HALL3-Demand-Pfad-Tests greifen.
+    fake_ext = printer.objects['extruder']
+    t = 0.0
+    for _ in range(12):
+        fake_ext.last_position = t * 15.0
+        feeder.velocity_tracker.tick(t)
+        t += 0.025
     return printer, feeder
 
 

--- a/tests/test_feed_distance_accumulator_reset.py
+++ b/tests/test_feed_distance_accumulator_reset.py
@@ -77,6 +77,13 @@ def make_feeder(values=None):
     set_sensor_active(feeder, 'hall_overflow', False)
     set_sensor_active(feeder, 'hall_full', False)
     set_sensor_active(feeder, 'hall_empty', False)
+    # Wurzel-C-Praevention γ: Tracker vorbefuellen.
+    fake_ext = printer.objects['extruder']
+    t = 0.0
+    for _ in range(12):
+        fake_ext.last_position = t * 15.0
+        feeder.velocity_tracker.tick(t)
+        t += 0.025
     return printer, feeder
 
 

--- a/tests/test_flush_callback_bang_bang.py
+++ b/tests/test_flush_callback_bang_bang.py
@@ -51,6 +51,14 @@ def make_feeder(values=None):
     set_sensor_active(feeder, 'hall_overflow', False)
     set_sensor_active(feeder, 'hall_full', False)
     set_sensor_active(feeder, 'hall_empty', False)
+    # Wurzel-C-Praevention γ (2026-05-14): Tracker mit aktiver
+    # ext_vel vorbefuellen damit HALL3-Demand-Pfad-Tests funktionieren.
+    fake_ext = printer.objects['extruder']
+    t = 0.0
+    for _ in range(12):
+        fake_ext.last_position = t * 15.0
+        feeder.velocity_tracker.tick(t)
+        t += 0.025
     return printer, feeder
 
 

--- a/tests/test_hall3_demand_semantics.py
+++ b/tests/test_hall3_demand_semantics.py
@@ -1,0 +1,217 @@
+"""HALL3-Demand-Semantik — Wurzel C Praeventionsfix.
+
+Hardware-Beleg (vier widerlegte Pre-Anchor-Iterationen):
+  V0/V1/D2/V3 Crashes traten alle beim Druckstart auf, wenn:
+    - HALL3=True (Buffer-Arm in entrance-Position, idle resting)
+    - Klipper geht zu state='printing'
+    - Idle-Suppression oeffnet
+    - _flush_submit_streaming_chunk feuert sofort
+    - Race mit PRINT_START Macro (SET_KINEMATIC_POSITION + TMC-UART)
+    -> MCU 'LLL_PLUS' shutdown: Timer too close
+
+Wurzel-Analyse: HALL3 hat zwei Bedeutungen:
+  1. Aktiver Print: Extruder zieht Filament -> Arm hochgezogen -> echter
+     Demand fuer Refill
+  2. Idle: Arm liegt natuerlich oben durch fehlende Zugkraft -> KEIN
+     Demand, Buffer ist einfach nur in Ruhe
+
+Soft-Throttle (Hotfix 7) behandelt beide Faelle gleich (HALL3 -> MIN_FLOOR
+*1.5). Im Druckstart-Moment laeuft das in den USB-Burst-Race.
+
+Fix (γ): HALL3 nur als Demand-Signal interpretieren wenn der Extruder
+tatsaechlich Filament zieht (tracker_velocity > 0). Bei idle / Pre-Print
+ohne ext_vel -> target_speed=0 -> kein Submit -> kein Race.
+
+Komplementaer zu PR #39 (Watchdog hall_empty Bypass) und Maintainer
+97e97e7 (forced_t0 sanitize). Eliminiert die haeufigste Trigger-
+Bedingung fuer Wurzel C strukturell, ohne Pre-Anchor-Versuch.
+"""
+
+import pytest
+
+from fakes_klipper import FakeConfig, FakePrinter, FakePrintStats
+from klipper_extras import buffer_feeder
+
+
+def set_sensor_active(feeder, sensor_name, active):
+    polarity_flip = feeder._pin_polarity_flip[sensor_name]
+    raw = (not active) if polarity_flip else active
+    feeder._pin_stable_state[sensor_name] = raw
+    feeder._pin_raw_state[sensor_name] = raw
+
+
+def make_modulator_feeder(values=None):
+    base = {"use_flush_callback_bang_bang": True}
+    if values:
+        base.update(values)
+    printer = FakePrinter()
+    printer.objects["print_stats"] = FakePrintStats(state="printing")
+    config = FakeConfig(printer=printer, values=base)
+    feeder = buffer_feeder.BufferFeeder(config)
+    printer.fire_event('klippy:connect')
+    feeder._startup_grace_done = True
+    feeder._state = buffer_feeder.STATE_AUTO
+    set_sensor_active(feeder, 'hall_overflow', False)
+    set_sensor_active(feeder, 'hall_full', False)
+    set_sensor_active(feeder, 'hall_empty', False)
+    return printer, feeder
+
+
+def populate_tracker(feeder, velocity, samples=12):
+    """Tracker mit linearer Position-Steigerung fuellen bis is_ready=True."""
+    fake_ext = feeder.printer.objects['extruder']
+    fake_ext.last_position = 0.0
+    t = 0.0
+    for _ in range(samples):
+        fake_ext.last_position = t * velocity
+        feeder.velocity_tracker.tick(t)
+        t += 0.025
+
+
+# ---------------------------------------------------------------------------
+# Wurzel-C-Fix γ — HALL3 ohne ext_vel ist KEIN Demand
+# ---------------------------------------------------------------------------
+
+
+def test_hall3_alone_without_extruder_velocity_returns_zero():
+    """Wurzel-C-Fix γ Kern: HALL3=True bei idle (kein extruder-Verbrauch)
+    -> target_speed=0. Idle-Buffer-Arm-Position ist KEIN demand.
+
+    Pre-Fix: hall_empty=True -> MIN_FLOOR (=15) auch bei ext_vel=0 ->
+    triggert streaming-submit beim Druckstart -> Race mit
+    SET_KINEMATIC_POSITION + TMC-UART -> Timer too close.
+
+    Fix: HALL3 nur als demand wenn ext_vel > 0 (Extruder zieht aktiv).
+    """
+    printer, feeder = make_modulator_feeder()
+    set_sensor_active(feeder, 'hall_empty', True)
+    # Tracker NICHT zu ready bringen -> ext_vel=0
+    assert not feeder.velocity_tracker.is_ready()
+
+    result = feeder._compute_target_feed_speed()
+    assert result == 0.0, (
+        "HALL3+idle (kein ext_vel): target_speed=0. "
+        "Erhalten: %.3f mm/s" % result)
+
+
+def test_hall3_with_tracker_ready_but_zero_velocity_returns_zero():
+    """HALL3=True, tracker ready aber ext_vel=0 (Pause / Heat-Up):
+    immer noch KEIN Demand. Tracker-readiness allein reicht nicht;
+    es muss aktive Bewegung sein."""
+    printer, feeder = make_modulator_feeder()
+    set_sensor_active(feeder, 'hall_empty', True)
+    # Tracker zu ready bringen, aber mit velocity=0
+    populate_tracker(feeder, velocity=0.0)
+    assert feeder.velocity_tracker.is_ready()
+    assert feeder.velocity_tracker.get_velocity() == 0.0
+
+    result = feeder._compute_target_feed_speed()
+    assert result == 0.0, (
+        "HALL3 + tracker ready + ext_vel=0: target_speed=0. "
+        "Erhalten: %.3f" % result)
+
+
+def test_hall3_with_active_extruder_returns_demand():
+    """Regression: HALL3=True UND Extruder zieht aktiv (ext_vel>0):
+    Soft-Throttle-Demand wie vorher = max(MIN_FLOOR, ext_vel*1.5).
+    Mid-Print-Refill bleibt unveraendert.
+    """
+    printer, feeder = make_modulator_feeder()
+    set_sensor_active(feeder, 'hall_empty', True)
+    populate_tracker(feeder, velocity=15.0)
+
+    result = feeder._compute_target_feed_speed()
+    # ext_vel=15 -> 15*1.5=22.5 mm/s (wie Hotfix 7 Soft-Throttle)
+    assert result == pytest.approx(22.5, abs=0.1), (
+        "HALL3 + ext_vel=15: target_speed=22.5 (Soft-Throttle). "
+        "Erhalten: %.3f" % result)
+
+
+def test_hall3_low_velocity_still_uses_min_floor():
+    """HALL3 + sehr kleine extruder-vel (0 < vel < MIN_FLOOR):
+    soll target_speed = MIN_FLOOR setzen (Soft-Throttle-Untergrenze).
+    Wichtig fuer den Start des Mid-Print-Refills bei langsamer
+    Anlauf-Phase."""
+    printer, feeder = make_modulator_feeder()
+    set_sensor_active(feeder, 'hall_empty', True)
+    # vel < MIN_FLOOR (typisch 15) aber > 0
+    populate_tracker(feeder, velocity=5.0)
+
+    result = feeder._compute_target_feed_speed()
+    # ext_vel=5 -> 5*1.5=7.5, aber max(7.5, MIN_FLOOR=15)=15
+    assert result == pytest.approx(feeder.min_feed_floor, abs=0.1), (
+        "HALL3 + low ext_vel: target_speed=MIN_FLOOR (Soft-Throttle "
+        "Untergrenze). Erhalten: %.3f, erwartet: %.3f"
+        % (result, feeder.min_feed_floor))
+
+
+# ---------------------------------------------------------------------------
+# Regression: andere Pfade bleiben unveraendert
+# ---------------------------------------------------------------------------
+
+
+def test_hall1_overflow_returns_zero_regardless_of_extruder_velocity():
+    """Regression: HALL1=True -> 0 unabhaengig von ext_vel."""
+    printer, feeder = make_modulator_feeder()
+    set_sensor_active(feeder, 'hall_overflow', True)
+    populate_tracker(feeder, velocity=20.0)
+    assert feeder._compute_target_feed_speed() == 0.0
+
+
+def test_hall2_full_returns_zero_regardless_of_extruder_velocity():
+    """Regression: HALL2=True -> 0 (drain via toolhead, kein push)."""
+    printer, feeder = make_modulator_feeder()
+    set_sensor_active(feeder, 'hall_full', True)
+    populate_tracker(feeder, velocity=20.0)
+    assert feeder._compute_target_feed_speed() == 0.0
+
+
+def test_zwischenzone_with_active_extruder_unchanged():
+    """Regression: Zwischenzone + ext_vel>0 -> max(MIN_FLOOR, ext_vel*gain)."""
+    printer, feeder = make_modulator_feeder()
+    # Alle halls inactive
+    populate_tracker(feeder, velocity=20.0)
+    result = feeder._compute_target_feed_speed()
+    # max(15, 20*1.10=22) = 22
+    assert result == pytest.approx(22.0, abs=1.0)
+
+
+def test_zwischenzone_idle_unchanged():
+    """Regression: Zwischenzone + ext_vel=0 -> 0 (unveraendert)."""
+    printer, feeder = make_modulator_feeder()
+    # Alle halls inactive, tracker not ready
+    result = feeder._compute_target_feed_speed()
+    assert result == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Wurzel-C-Trigger eliminiert
+# ---------------------------------------------------------------------------
+
+
+def test_print_start_with_hall3_no_extrusion_no_streaming_submit():
+    """End-to-end Trigger-Test: HALL3=True + state='printing' +
+    ext_vel=0 (frisch nach SD-Print-Start, vor Heat-Up). Erwartung:
+    _flush_submit_streaming_chunk submittet KEINEN streaming-chunk —
+    weil target_speed=0 in dieser Wurzel-Konstellation.
+
+    Das eliminiert die haeufigste Wurzel-C-Trigger-Bedingung
+    strukturell.
+    """
+    printer, feeder = make_modulator_feeder()
+    motion_q = printer.lookup_object('motion_queuing')
+    set_sensor_active(feeder, 'hall_empty', True)
+    # Tracker not ready (frisch nach Klipper-restart)
+    assert not feeder.velocity_tracker.is_ready()
+    feeder._stepcompress_primed = True
+
+    feeder.reactor.now = 10.0
+    appends_before = len(motion_q.append_calls)
+    motion_q.trigger_flush(flush_time=10.0, step_gen_time=10.0)
+    own = [c for c in motion_q.append_calls[appends_before:]
+           if c[0] is feeder.trapq]
+
+    assert len(own) == 0, (
+        "Wurzel-C-Trigger eliminiert: HALL3 + idle (kein ext_vel) "
+        "DARF KEIN streaming-submit ausloesen. Erhalten: %d appends"
+        % len(own))

--- a/tests/test_idle_watchdog_anchor.py
+++ b/tests/test_idle_watchdog_anchor.py
@@ -298,3 +298,103 @@ def test_anchor_after_two_full_windows_fires_again(monkeypatch):
     assert len(calls) == 2, (
         "After a full idle_anchor_gap elapses since the previous "
         "anchor, the watchdog must re-fire.")
+
+
+# ---------------------------------------------------------------------------
+# Issue #31 Refactor-Port Regression: Watchdog vs. hall_empty + flush_callback
+# ---------------------------------------------------------------------------
+#
+# Hotfix 10 (Hardware 2026-05-14, klippy.log Z.363): MCU 'LLL_PLUS' shutdown
+# "Timer too close" beim ersten Druckstart nach Klipper-Idle (gap=257.7s).
+#
+# Wurzel: Der P7-75 Sub-Gate `not self.hall_empty` blockierte den Watchdog
+# auch im flush-callback-bang-bang-Pfad (use_flush_callback_bang_bang=True).
+# Dort ist `_bang_bang_tick` ein No-Op — der Race vor dem das Gate
+# schuetzen sollte (Bang-Bang-Feed-Request vs. Watchdog-Anchor) existiert
+# nur im klassischen Reactor-Tick-Pfad. Im flush-callback-Pfad ist der
+# Watchdog die EINZIGE Schutzschicht gegen stale last_step_clock waehrend
+# Klipper-Idle (kein motion_queuing-Callback ohne Steps).
+#
+# Fix: hall_empty-Gate konditional an use_flush_callback_bang_bang=False
+# binden. Mit flush_callback_bang_bang=True (= C-cont Streaming-Modus)
+# feuert der Watchdog auch bei hall_empty=True.
+#
+# Status: Im Refactor (Commit 02e9b33) wurde nur Teil 2 von Hotfix 10
+# portiert (Idle-Suppression in _on_mcu_flush). Teil 1 (Watchdog-Gate-
+# Anpassung) fehlt — diese Tests sind die TDD-Regression.
+
+
+def test_watchdog_fires_in_auto_with_hall_empty_when_flush_callback_bangbang(
+        monkeypatch):
+    """Hotfix 10 (Issue #31 Refactor-Port-Regression):
+    Im flush-callback-bang-bang-Pfad (use_flush_callback_bang_bang=True)
+    muss der Watchdog auch bei hall_empty=True feuern.
+
+    Pre-condition fuer den realen Hardware-Crash:
+      - state=AUTO, kein Druck aktiv (print_stats=standby)
+      - hall_empty=True (Buffer-Arm in entrance-Position, normales Idle)
+      - use_flush_callback_bang_bang=True (C-cont Streaming-Modus)
+      - _continuous_feed=False (Bang-Bang nicht aktiv)
+      - gap > idle_anchor_gap
+
+    Ohne Fix bleibt last_step_clock stale → erster Submit nach PRINT_START
+    crasht mit Timer-too-close. Mit Fix feuert der Watchdog regelmaessig
+    den 0.05mm-Micro-Anchor und haelt den Cursor frisch.
+
+    Hardware-Beleg: klippy_refactor_timer_too_close.log Z.3086 (clock=
+    4052274463, 0 'auto anchor fired' Events in der gesamten Idle-Phase).
+    """
+    _, feeder = make_idle_feeder(
+        values={'use_flush_callback_bang_bang': True})
+    feeder._state = buffer_feeder.STATE_AUTO
+    # Bang-Bang muss quiescent sein (sonst greift der continuous_feed-Gate).
+    feeder._continuous_feed = False
+    # hall_empty=True simuliert Filament-im-Buffer-Idle: Arm haengt in
+    # entrance-Position.
+    set_sensor_active(feeder, 'hall_empty', True)
+    set_sensor_active(feeder, 'hall_full', False)
+    set_sensor_active(feeder, 'hall_overflow', False)
+
+    calls = count_anchor_calls(monkeypatch, feeder)
+    feeder.reactor.now = 20.0
+    feeder._last_move_end_time = 0.0
+    feeder._main_tick(eventtime=20.0)
+
+    assert len(calls) == 1, (
+        "Hotfix 10: Watchdog MUSS in STATE_AUTO mit hall_empty=True "
+        "feuern, wenn use_flush_callback_bang_bang=True. Ohne diesen "
+        "Anchor altert last_step_clock waehrend Klipper-Idle und der "
+        "erste Submit nach PRINT_START crasht mit Timer-too-close.")
+
+
+def test_watchdog_still_blocks_in_auto_with_hall_empty_when_classic_bangbang(
+        monkeypatch):
+    """Regression P7-75 klassischer Pfad: bei use_flush_callback_bang_-
+    bang=False bleibt das hall_empty-Gate aktiv.
+
+    Hier laeuft _bang_bang_tick im Reactor-Tick als echter Submitter.
+    Ein Watchdog-Anchor parallel dazu wuerde mit dem Bang-Bang-Feed-
+    Request racen — genau der Race vor dem P7-75 urspruenglich
+    geschuetzt hatte. Das Gate muss in diesem Pfad weiter blocken.
+    """
+    _, feeder = make_idle_feeder(
+        values={'use_flush_callback_bang_bang': False})
+    feeder._state = buffer_feeder.STATE_AUTO
+    feeder._continuous_feed = False
+    set_sensor_active(feeder, 'hall_empty', True)
+    set_sensor_active(feeder, 'hall_full', False)
+    set_sensor_active(feeder, 'hall_overflow', False)
+    # Bang-bang-tick patchen um Observation eng zu halten (existierendes
+    # Pattern in test_state_auto_with_active_bangbang_does_not_fire).
+    monkeypatch.setattr(feeder, "_bang_bang_tick", lambda et: None)
+
+    calls = count_anchor_calls(monkeypatch, feeder)
+    feeder.reactor.now = 20.0
+    feeder._last_move_end_time = 0.0
+    feeder._main_tick(eventtime=20.0)
+
+    assert calls == [], (
+        "P7-75 klassischer Reactor-Tick-Pfad: hall_empty-Gate muss "
+        "Watchdog weiter blocken, wenn use_flush_callback_bang_bang="
+        "False. Sonst race zwischen Watchdog-Anchor und Bang-Bang-"
+        "Feed-Request im _bang_bang_tick.")

--- a/tests/test_no_double_submit_in_auto.py
+++ b/tests/test_no_double_submit_in_auto.py
@@ -49,6 +49,13 @@ def make_feeder(values=None):
     set_sensor_active(feeder, 'hall_full', False)
     set_sensor_active(feeder, 'hall_empty', False)
     set_sensor_active(feeder, 'entrance', True)
+    # Wurzel-C-Praevention γ: Tracker vorbefuellen.
+    fake_ext = printer.objects['extruder']
+    t = 0.0
+    for _ in range(12):
+        fake_ext.last_position = t * 15.0
+        feeder.velocity_tracker.tick(t)
+        t += 0.025
     return printer, feeder
 
 

--- a/tests/test_resume_anchor_after_overflow.py
+++ b/tests/test_resume_anchor_after_overflow.py
@@ -68,6 +68,13 @@ def make_feeder(values=None):
     set_sensor_active(feeder, 'hall_overflow', False)
     set_sensor_active(feeder, 'hall_full', False)
     set_sensor_active(feeder, 'hall_empty', False)
+    # Wurzel-C-Praevention γ: Tracker vorbefuellen.
+    fake_ext = printer.objects['extruder']
+    t = 0.0
+    for _ in range(12):
+        fake_ext.last_position = t * 15.0
+        feeder.velocity_tracker.tick(t)
+        t += 0.025
     return printer, feeder
 
 

--- a/tests/test_streaming_pipeline_auto.py
+++ b/tests/test_streaming_pipeline_auto.py
@@ -98,6 +98,17 @@ def make_feeder(values=None):
     set_sensor_active(feeder, 'hall_overflow', False)
     set_sensor_active(feeder, 'hall_full', False)
     set_sensor_active(feeder, 'hall_empty', False)
+    # Wurzel-C-Praevention γ (2026-05-14): HALL3 alleine ist KEIN
+    # demand mehr. Tests die "HALL3 -> submit" pruefen muessen jetzt
+    # auch tracker_velocity > 0 haben. Tracker hier vorgefuellt fuer
+    # die meisten streaming-Pipeline-Tests; Tests die expliziter
+    # tracker_not_ready brauchen, koennen ihn ueberschreiben.
+    fake_ext = printer.objects['extruder']
+    t = 0.0
+    for _ in range(12):
+        fake_ext.last_position = t * 15.0
+        feeder.velocity_tracker.tick(t)
+        t += 0.025
     return printer, feeder
 
 


### PR DESCRIPTION
> Closes #41 (partial — Wurzel C Trigger eliminiert; tieferes MCU-Pipeline-Race von Issue #41 bleibt strukturelle Frage)

## Hintergrund

Drei Pre-Anchor-Iterationen aus dem zurueckgezogenen PR #40 wurden alle durch HW-Tests widerlegt (V1 Burst-Race, D2 motion_queuing aggressive-mode, V3 quiet-window). Issue #41 hat das MCU-CPU-Race als wahrscheinliche Wurzel identifiziert: stepper-timer + TMC-UART + SET_KINEMATIC_POSITION konkurrieren um LLL_PLUS-MCU-CPU waehrend PRINT_START.

Dieser PR greift an einem **anderen Eingriffspunkt** an — nicht submit-timing, sondern **demand-computation**.

## Wurzel-Analyse

HALL3=True (Buffer-Arm in entrance-Position) hat zwei sehr unterschiedliche Bedeutungen:

1. **Aktiver Print:** Extruder zieht Filament -> Arm hochgezogen durch Zugkraft -> echter Refill-Demand
2. **Idle / Pre-Print:** Arm liegt natuerlich oben durch Eigengewicht -> KEIN Demand, Buffer in Ruhe

Soft-Throttle (Hotfix 7) behandelt beide Faelle gleich:
```python
if self.hall_empty:
    return MIN_FLOOR * 1.5  # = 22.5 mm/s "demand"
```

Im Druckstart-Moment oeffnet sich die Idle-Suppression (`state='printing'`), `buffer_feeder` feuert sofort einen streaming-submit, MCU laeuft in USB-Burst-Race mit `SET_KINEMATIC_POSITION` + TMC-UART -> **Timer too close**. Vier konsistente HW-Test-Belege vor diesem Fix.

## Fix

HALL3 nur als Demand interpretieren, **wenn der Extruder tatsaechlich Filament zieht** (velocity_tracker.get_velocity() > 0):

```python
if self.hall_empty:
    # Wurzel-C-Praevention: HALL3 ohne aktiven Extruder ist
    # KEIN Demand sondern Idle-Resting-Position.
    if not vel_ready or extruder_vel <= floor_epsilon:
        self._modulator_feeding = False
        return 0.0
    # Sonst Soft-Throttle wie vorher (unveraendert)
    if extruder_vel < floor - floor_epsilon:
        return floor
    return min(max(extruder_vel * 1.5, floor), self.feed_speed)
```

## Effekt strukturell

| Situation | HALL3 | Extruder? | Vorher | Mit Fix |
|---|---|---|---|---|
| Klipper idle, Arm ruht oben | ✓ | nein | feed @ 15 mm/s (**Race-Trigger**) | nicht feeden |
| Druckstart, heizt noch | ✓ | nein | feed @ 15 mm/s (**Race-Trigger**) | nicht feeden |
| First Layer laeuft, Buffer wird leer | ✓ | ja | feed @ 22 mm/s | feed @ 22 mm/s (unveraendert) |
| Mid-Print, Buffer drained | ✓ | ja | feed @ 22 mm/s | feed @ 22 mm/s (unveraendert) |

## Begleitende Aenderungen

- `klipper_extras/buffer_feeder.py`: `_compute_target_feed_speed` HALL3-branch (5 Zeilen geaendert)
- `tests/test_hall3_demand_semantics.py`: 9 neue Tests (RED -> GREEN)
- `tests/test_c_cont_streaming.py`: zwei alte Hotfix-4-Tests an neue Semantik angepasst (die `MIN_FLOOR`-bei-not_ready-Annahme war genau der Wurzel-C-Trigger)
- 6 weitere Test-Files: Helper-Fixture um Tracker mit `ext_vel>0` vorzubefuellen
- **Full-Suite:** 405 -> 414 passed, 0 echte Regressionen

## Hardware-Test-Status

**3x PRINT_START unter idealer Crash-Konstellation (HALL3=True, frisch geboot'eter Klipper, stale cursor) — 0 Crashes.**

Vor diesem Fix: 4/4 HW-Tests crashen.

| Druckversuch | Klipper-State | HALL3 | Resultat |
|---|---|---|---|
| 1 | Boot + 2-min Idle | True | flush_no_demand, kein Submit, kein Crash |
| 2 | User-Restart nach QGL-Fail | True | flush_no_demand, kein Submit, kein Crash |
| 3 | User-Restart nach QGL-Fail | True | flush_no_demand, kein Submit, kein Crash |

**Belege im klippy.log:**
- 0 `Timer too close` events
- 0 `Invalid sequence` events
- 0 `flush_submit` events (Buffer-Feeder bleibt korrekt still waehrend PRINT_START + QGL + Heating)
- Kontinuierliche `flush_no_demand` events: `target_speed=0 hall3=True ready=True` ← exakt das gewollte Verhalten

## End-to-End-Validierung (noch ausstehend)

Der HW-Drucker kann derzeit nicht ueber QGL hinauskommen — orthogonales mechanisches Issue:
```
Retries aborting: Probed points range is increasing.
Possibly Z motor numbering is wrong
```

Das ist eine **Z-Motor-Mechanik/Probe-Calibration**-Frage, kein BufferPLUS-Issue. Sobald der Drucker QGL passiert, kann End-to-End validiert werden:
- Mid-Print Buffer-Refill (HALL3=True + tracker_vel>0 -> Soft-Throttle wie vorher)
- Print-Ende sauberes Bereinigen

## Pre-Commitment (Iron Law)

Anderer Eingriffspunkt als PR #40 (drei widerlegte Pre-Anchor-Iterationen). Demand-Computation statt submit-timing. Kein "vierter Versuch derselben Idee".

Falls dieser Fix in E2E-Tests trotzdem Wurzel C nicht abdeckt: KEIN V5 ohne deinen Architektur-Input. Issue #41 bleibt offen fuer das tiefere MCU-Pipeline-Race.

## Verbindung zu Issue #41

Issue #41 fragt nach Klipper-Pipeline-Ebene (motion_queuing-Trapq-Trennung, TMC-UART-Backpressure, Stepper-Timer-Prioritaet). Dieser PR adressiert das nicht direkt — er **eliminiert die haeufigste Trigger-Bedingung** auf BufferPLUS-Ebene. Das tiefere MCU-Race bleibt theoretisch existent (z.B. bei extremer Mid-Print-Demand-Spike-Konstellation), aber wir haben keinen HW-Repro mehr dafuer.