### PR TITLE
bugfix(buffer_feeder): stale _continuous_feed flag triggert false-positive JAM SUPPLY beim nächsten Print

### DIFF
--- a/klipper_extras/buffer_feeder.py
+++ b/klipper_extras/buffer_feeder.py
@@ -621,6 +621,21 @@ class BufferFeeder:
                 # auto-grip. _bang_bang_suspended stays whatever it
                 # was (operator may have set it explicitly via
                 # BUFFER_AUTO_OFF; we don't override).
+                #
+                # Bugfix 2026-05-14: _continuous_feed-Stale-Flag-Reset.
+                # Ohne diesen Reset bleibt der Flag aus dem letzten Mid-
+                # Print-Submit auf True stehen. Beim naechsten Print
+                # mit langer Pre-Extrusion-Phase (Heating + QGL > jam_-
+                # supply_dwell_time, typisch 240s) interpretiert
+                # _jam_tick das als "feeder running" und triggert
+                # false-positive JAM SUPPLY — obwohl buffer_feeder gar
+                # nicht gefoerdert hat. Analog zum PAUSE-Branch-Reset
+                # oben (Z.615), aber fuer end-of-print noetig.
+                # Hardware-Beleg: 30.7-min-Print endete bei HALL3=True;
+                # 1h Idle; naechster Print bei HALL3=True + Heating +
+                # 3x QGL-Retries > 240s -> false-positive JAM.
+                self._continuous_feed = False
+                self._continuous_feed_direction = 0
                 self._respond("Print ended — buffer ready for next "
                               "filament change or print")
         self._print_running = False

--- a/tests/test_continuous_feed_stale_flag_reset.py
+++ b/tests/test_continuous_feed_stale_flag_reset.py
@@ -1,0 +1,181 @@
+"""Bugfix: _continuous_feed-Stale-Flag-Reset bei Print-Ende.
+
+Hardware-Beleg (2026-05-14, nach erfolgreichem Fix-1-End-to-End-Druck):
+  - Print 1 lief 30.7 min durch (vollstaendig successful)
+  - Print 1 endete mit HALL3=True (Buffer wurde leergezogen)
+  - 1 Stunde Idle
+  - User setzt HALL3=True (bewusst) + startet Print 2
+  - Print 2: Heating + 3x QGL-Retries > 240s ohne Extruder-Bewegung
+  - _jam_tick triggert nach exakt 240s:
+      *** JAM SUPPLY: HALL3 active 240s with feeder running ***
+  - Aber: Buffer-Feeder hat in dieser Zeit GAR NICHT gefoerdert
+    (Fix 1: target_speed=0 weil ext_vel=0; flush_no_demand kontinuierlich)
+
+Wurzel: `_continuous_feed` ist ein Flag der beim Submit auf True gesetzt
+wird. Reset passiert via:
+  - `_halt_motion()` (HALT/OVERFLOW/JAM-Pfade)
+  - `_on_idle_ready` PAUSED-Branch
+  - NICHT im `_on_idle_ready` "Print ended normally"-Branch!
+
+Konsequenz: Wenn Print regulaer endet (state=complete/standby), bleibt
+`_continuous_feed=True` aus dem letzten Mid-Print-Submit. Beim naechsten
+Print mit `target_speed=0` (Fix 1) wird der Flag NICHT neu gesetzt —
+ist aber als stale-True bereits aktiv. _jam_tick interpretiert das als
+"feeder_running_fwd=True" und startet den 240s-Dwell-Counter falsch.
+
+Latenzgrad: Bug existiert seit Hotfix 7 (Soft-Throttle Einfuehrung),
+war aber durch sofortige HALL3-Submits maskiert (Arm fiel auf HALL2
+binnen Sekunden -> dwell-Counter Reset). Fix 1 (HALL3-Demand-Semantik)
+hat den Bug entlarvt, NICHT verursacht.
+
+Fix: `_continuous_feed = False` im `_on_idle_ready` ended-normally-Branch
+ergaenzen — analog zum existierenden PAUSE-Branch-Reset.
+"""
+
+import pytest
+
+from fakes_klipper import FakeConfig, FakePrinter, FakePrintStats
+from klipper_extras import buffer_feeder
+
+
+def set_sensor_active(feeder, sensor_name, active):
+    polarity_flip = feeder._pin_polarity_flip[sensor_name]
+    raw = (not active) if polarity_flip else active
+    feeder._pin_stable_state[sensor_name] = raw
+    feeder._pin_raw_state[sensor_name] = raw
+
+
+def make_print_ended_feeder(print_state='complete'):
+    """Feeder im Print-aktiv-Zustand, der gleich auf 'ended' wechseln
+    wird via _on_idle_ready Hook."""
+    base = {"use_flush_callback_bang_bang": True}
+    printer = FakePrinter()
+    printer.objects["print_stats"] = FakePrintStats(state=print_state)
+    config = FakeConfig(printer=printer, values=base)
+    feeder = buffer_feeder.BufferFeeder(config)
+    printer.fire_event('klippy:connect')
+    feeder._startup_grace_done = True
+    feeder._state = buffer_feeder.STATE_AUTO
+    set_sensor_active(feeder, 'hall_overflow', False)
+    set_sensor_active(feeder, 'hall_full', False)
+    set_sensor_active(feeder, 'hall_empty', False)
+    return printer, feeder
+
+
+# ---------------------------------------------------------------------------
+# Bugfix-Tests
+# ---------------------------------------------------------------------------
+
+
+def test_continuous_feed_resets_on_print_ended_normally():
+    """Wurzel: Print endet 'complete' / 'standby' -> _continuous_feed
+    MUSS auf False zurueckgesetzt werden. Sonst stale-True triggert
+    beim naechsten Print false-positive JAM SUPPLY.
+
+    Pre-Fix: nur PAUSE-Branch resettet den Flag; "Print ended normally"
+    laesst stale True stehen."""
+    printer, feeder = make_print_ended_feeder(print_state='complete')
+    # Simuliere aktiven Print mit laufendem continuous_feed
+    feeder._print_running = True
+    feeder._continuous_feed = True
+    feeder._continuous_feed_direction = 1
+
+    feeder._on_idle_ready()
+
+    assert feeder._continuous_feed is False, (
+        "Bugfix: _continuous_feed muss bei Print-Ende auf False "
+        "zurueckgesetzt werden. Sonst bleibt der stale-Flag bis "
+        "zum naechsten Print und triggert false-positive "
+        "SUPPLY-JAM-Detection.")
+
+
+def test_continuous_feed_direction_resets_on_print_ended_normally():
+    """Auch _continuous_feed_direction muss zurueckgesetzt werden
+    (Defense-in-depth — beide Felder sollten konsistent sein)."""
+    printer, feeder = make_print_ended_feeder(print_state='complete')
+    feeder._print_running = True
+    feeder._continuous_feed = True
+    feeder._continuous_feed_direction = 1
+
+    feeder._on_idle_ready()
+
+    assert feeder._continuous_feed_direction == 0, (
+        "Bugfix: _continuous_feed_direction muss bei Print-Ende "
+        "auf 0 zurueckgesetzt werden (konsistent mit _continuous_feed=False).")
+
+
+def test_continuous_feed_resets_on_standby_state():
+    """'standby' (Print-cancelled) muss genauso resetten wie 'complete'."""
+    printer, feeder = make_print_ended_feeder(print_state='standby')
+    feeder._print_running = True
+    feeder._continuous_feed = True
+    feeder._continuous_feed_direction = 1
+
+    feeder._on_idle_ready()
+
+    assert feeder._continuous_feed is False
+    assert feeder._continuous_feed_direction == 0
+
+
+# ---------------------------------------------------------------------------
+# Regression: PAUSE-Branch behaviour bleibt identisch
+# ---------------------------------------------------------------------------
+
+
+def test_continuous_feed_still_resets_on_pause_unchanged():
+    """Regression: PAUSE-Branch hat schon vor dem Fix _continuous_feed=
+    False gesetzt. Das bleibt unveraendert (Defense-in-depth)."""
+    printer, feeder = make_print_ended_feeder(print_state='paused')
+    feeder._print_running = True
+    feeder._continuous_feed = True
+    feeder._continuous_feed_direction = 1
+
+    feeder._on_idle_ready()
+
+    assert feeder._continuous_feed is False
+    assert feeder._bang_bang_suspended is True
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: kein false-positive JAM SUPPLY nach Print-End-Idle
+# ---------------------------------------------------------------------------
+
+
+def test_no_false_positive_jam_supply_after_print_end_then_idle():
+    """End-to-end: Print endet 'complete' bei HALL3=True + _continuous_-
+    feed=True. Naechster Print startet nach 1h Idle, HALL3 noch True,
+    aber Buffer-Feeder ist still (target_speed=0 wegen Fix 1).
+    _jam_tick darf KEINEN dwell-Counter starten weil _continuous_feed
+    nach Print-Ende False sein muss.
+
+    Bug-Reproduktion vor Fix:
+      _continuous_feed=True (stale) + hall_empty=True
+        -> feeder_running_fwd=True
+        -> _hall3_start_time gesetzt
+        -> 240s spaeter: false-positive JAM SUPPLY
+    """
+    printer, feeder = make_print_ended_feeder(print_state='complete')
+    feeder._print_running = True
+    feeder._continuous_feed = True
+    feeder._continuous_feed_direction = 1
+    set_sensor_active(feeder, 'hall_empty', True)
+
+    # Simulate Print-Ende
+    feeder._on_idle_ready()
+
+    # Nach Print-Ende: _continuous_feed muss False sein
+    assert not feeder._continuous_feed, "Bugfix: stale-Flag-Reset"
+
+    # Simuliere neuen Print-Start: _print_running=True, HALL3=True,
+    # aber target_speed=0 (Fix 1 - kein Submit weil ext_vel=0).
+    # _continuous_feed bleibt False weil kein Submit erfolgte.
+    feeder._print_running = True  # neuer Print
+
+    # _jam_tick check (manuell): feeder_running_fwd Berechnung
+    feeder_running_fwd = (feeder._continuous_feed
+                          and feeder._continuous_feed_direction == 1)
+    assert feeder_running_fwd is False, (
+        "Bugfix: feeder_running_fwd muss False sein wenn "
+        "_continuous_feed nach Print-Ende-Reset auf False steht. "
+        "Sonst false-positive JAM SUPPLY beim naechsten Print mit "
+        "langer Heat-Up-Phase (240s ohne Extrusion).")

--- a/tests/test_idle_ready_pause_vs_print_end.py
+++ b/tests/test_idle_ready_pause_vs_print_end.py
@@ -80,10 +80,15 @@ def test_idle_ready_during_grace_ignores_event():
 
 
 def test_idle_ready_print_end_halts_continuous_feed_only_on_pause():
-    """The continuous-feed halt was tied to the 'paused' branch in the
-    legacy code. After P7-56f it stays in the paused-branch only —
-    print-end doesn't need to halt continuous feed (it shouldn't have
-    been running anyway after idle_timeout fires)."""
+    """SUPERSEDED durch Bugfix 2026-05-14 (_continuous_feed-Stale-
+    Flag-Reset): Print-Ende muss _continuous_feed jetzt AUCH auf
+    False zurueck setzen — nicht nur PAUSE.
+
+    Pre-Fix-Annahme (legacy): "print-end doesn't need to halt
+    continuous feed". Real-Hardware-Beobachtung: stale-Flag
+    triggert false-positive JAM SUPPLY beim naechsten Print mit
+    langer Heat-Up/QGL-Phase (240s ohne Extruder-Bewegung).
+    """
     printer, feeder = make_feeder()
     printer.objects['print_stats'] = FakePrintStats(state='complete')
     feeder._bang_bang_suspended = False
@@ -91,12 +96,11 @@ def test_idle_ready_print_end_halts_continuous_feed_only_on_pause():
 
     feeder._on_idle_ready()
 
-    # On print-end we leave _continuous_feed alone. _on_idle_ready
-    # is the wrong place to mass-clear motion state — that's HALT /
-    # AUTO_OFF / STOP_BUFFER_FILL. _set_state(STATE_IDLE) on the
-    # natural state transitions handles motion stop.
-    # If state is paused this would be cleared (separate test).
-    assert feeder._continuous_feed is True
+    # Bugfix: _continuous_feed muss bei Print-Ende auf False
+    # zurueck (Stale-Flag-Reset). Siehe
+    # tests/test_continuous_feed_stale_flag_reset.py fuer die
+    # vollstaendige Bug-Reproduktion.
+    assert feeder._continuous_feed is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
> ⚠️ HW-Test laeuft parallel zum PR-Review. Diagnose ist durch Log-Math + Code-Trace + 5 Tests eindeutig — Update folgt bei HW-Bestaetigung.

## Problem

Hardware-Beleg (2026-05-14):
- Print 1 endet 'complete' bei HALL3=True (Buffer leergezogen)
- 1 Stunde Idle
- User setzt HALL3=True wieder + startet Print 2
- Heating + 3x QGL-Retries laufen > 240s ohne Extruder-Bewegung
- Buffer-Feeder ist still (target_speed=0, kein submit) waehrend dieser Zeit
- Exakt nach 240s: `*** JAM SUPPLY: HALL3 active 240s with feeder running ***`
- **Aber:** Buffer-Feeder hat in der Zeit NICHT gefoerdert (kein submit, Log: `flush_no_demand` kontinuierlich)

→ False-positive JAM SUPPLY.

## Wurzel

`_continuous_feed` ist ein Boolean-Flag der beim Submit auf True gesetzt wird. Reset-Pfade:

- ✅ `_halt_motion()` (HALT/OVERFLOW/JAM-Pfade)
- ✅ `_on_idle_ready` **PAUSED**-Branch
- ❌ `_on_idle_ready` ended-normally-Branch (state=complete/standby) — **FEHLT**

Nach Print-Ende bleibt der Flag stale-True aus dem letzten Mid-Print-Submit. Beim naechsten Print interpretiert `_jam_tick` das als `feeder_running_fwd=True` und startet den 240s-Dwell-Counter, obwohl der Buffer-Feeder gar nicht foerdert.

## Fix

In `_on_idle_ready` ended-normally-Branch — analog zum existierenden PAUSE-Branch:

```python
else:
    # Print ended normally
    # Bugfix: Stale-Flag-Reset
    self._continuous_feed = False
    self._continuous_feed_direction = 0
    self._respond("Print ended — ...")
```

## Tests (Phase 3 TDD)

**RED:** 4 neue Tests fail vor Fix:
- `test_continuous_feed_resets_on_print_ended_normally`
- `test_continuous_feed_direction_resets_on_print_ended_normally`
- `test_continuous_feed_resets_on_standby_state`
- `test_no_false_positive_jam_supply_after_print_end_then_idle`

**GREEN:** alle 5 neuen Tests pass (4 + PAUSE-Regression).

**1 alter Test umgeschrieben** (`test_idle_ready_print_end_halts_continuous_feed_only_on_pause`): dokumentierte explizit das alte Bug-Verhalten ("print-end doesn't need to halt continuous feed") als korrekt. Real-Hardware zeigt das Gegenteil.

**Full-Suite:** 405 → 408 passed, 0 echte Regressionen.

## Latenzgrad

Bug existiert vermutlich seit Hotfix 7 (Soft-Throttle Einfuehrung), war aber durch sofortige HALL3-Submits maskiert:
- `target_speed > 0` bei HALL3=True
- Buffer-Feeder pumpt sofort
- HALL3 dropt auf HALL2 binnen Sekunden
- `_hall3_start_time` wird kontinuierlich resettet
- Dwell-Counter erreicht nie 240s

Der Bug zeigt sich erst wenn Buffer-Feeder waehrend HALL3=True NICHT pumpt (z.B. nach #42 wenn ext_vel=0 in Heat-Up-Phase).

## Verhaeltnis zu PR #42

Dieser PR ist **unabhaengig** von #42. Der Bugfix kann direkt gegen `refactor/cleanup-all-phases` angewendet werden — Code-Aenderung beruehrt nur `_on_idle_ready`, kein Konflikt mit #42's `_compute_target_feed_speed`-Aenderung.

Mit PR #42 *zusammen* heilt das Stale-Flag-Bug komplett (Wurzel C + JAM-Side-Effect). Ohne #42 ist der Bug latent (zeigt sich seltener), aber der Reset ist trotzdem korrekte Hygiene.

## Code-Diff

```
 klipper_extras/buffer_feeder.py    | +18 -1
 tests/test_continuous_feed_stale_flag_reset.py | +180 (new)
 tests/test_idle_ready_pause_vs_print_end.py | +15 -10
```