### PR TITLE
fix: Symmetric step-gen-cursor-Race in _flush_move_in_flight vervollständigen

### DIFF
--- a/klipper_extras/buffer_feeder.py
+++ b/klipper_extras/buffer_feeder.py
@@ -1886,27 +1886,61 @@ class BufferFeeder:
     def _flush_move_in_flight(self, step_gen_time):
         """Flush-callback specific in-flight detection.
 
-        `reactor.monotonic()` can run slightly ahead of the callback's
-        `step_gen_time`. In that window `_move_in_flight()` may already
-        say False even though the step-generator cursor has not yet
-        advanced past the previously submitted trapezoid. Treat that as
-        still active so the next submit stays on the streaming path
-        (no extra motor_enable, no first-chunk re-anchor).
+        step_gen_time is the AUTHORITATIVE clock for "did the previous
+        move complete from stepcompress' perspective". `reactor.monotonic()`
+        can race in either direction relative to current_end, but only
+        step_gen_time decides whether new steps land before or after
+        stepcompress.last_step_clock.
+
+        Two reactor-race cases — both must be answered correctly:
+
+        1. reactor AHEAD of step_gen (c5b2e19): reactor.now() has moved
+           past current_end while step_gen_time still sits before it.
+           `_move_in_flight()` says False (False-Negative). Without the
+           cursor-lag branch, the next chunk would take the first-chunk
+           path with `_enable_stepper()` + re-anchor → inter-chunk gap
+           reopens and pipeline stalls. Fix (existing): treat as
+           in-flight when step_gen < current_end.
+
+        2. reactor BEHIND step_gen (2026-05-15): reactor.now() still
+           sits before current_end while step_gen_time has advanced
+           past it. `_move_in_flight()` says True (False-Positive).
+           Hardware-Crash 2026-05-15 klippy.log Z. 12848:
+             current_end=846.893  mcu_now=846.458  step_gen=847.158
+             remaining = current_end - step_gen = -0.265s (negative!)
+           Old code returned True via `_move_in_flight()`, anchored at
+           current_end=846.893. stepcompress.last_step_clock had already
+           advanced to ~847.158 → 7 steps landed before that clock →
+           collapsed to clock=0 → `stepcompress c=7 i=0`. Fix: check
+           step_gen against current_end FIRST and return False if past,
+           regardless of reactor — let the fresh-anchor path place t0
+           at step_gen + lead_time, safely ahead of last_step_clock.
+
+        See test_streaming_returns_done_when_step_gen_past_current_end_
+        and_reactor_behind for case 2,
+        test_streaming_uses_step_gen_cursor_when_reactor_time_is_ahead
+        for case 1.
         """
         if self._current_move is None:
             return False
+        current_end = self._current_move.get('end_time', 0.0)
+        # Case 2 (2026-05-15): step-gen authoritative. Past current_end
+        # ⇒ move done, no matter what reactor.now() says.
+        if step_gen_time >= current_end:
+            return False
+        # step_gen is still before current_end. Move is in flight per
+        # the authoritative clock. Two sub-cases for the reactor read:
         if self._move_in_flight():
             return True
-        current_end = self._current_move.get('end_time', 0.0)
-        if current_end > step_gen_time:
-            self._debug_event(
-                'flush_cursor_lag',
-                "treat in-flight by step_gen_time current_end=%.3f "
-                "step_gen=%.3f lme=%.3f",
-                current_end, step_gen_time, self._last_move_end_time,
-                min_interval=1.0)
-            return True
-        return False
+        # Case 1 (c5b2e19): reactor.now() raced ahead of step_gen but
+        # step_gen is still behind current_end. Log + treat in-flight.
+        self._debug_event(
+            'flush_cursor_lag',
+            "treat in-flight by step_gen_time current_end=%.3f "
+            "step_gen=%.3f lme=%.3f",
+            current_end, step_gen_time, self._last_move_end_time,
+            min_interval=1.0)
+        return True
 
     def _handle_overflow_prime_via_flush(self, step_gen_time):
         """Post-OVERFLOW prime via the flush-callback path.

--- a/tests/test_streaming_pipeline_auto.py
+++ b/tests/test_streaming_pipeline_auto.py
@@ -511,6 +511,62 @@ def test_streaming_uses_step_gen_cursor_when_reactor_time_is_ahead():
         "got %.3f" % t0)
 
 
+def test_streaming_returns_done_when_step_gen_past_current_end_and_reactor_behind():
+    """Mirror of cursor-lag race: step_gen has advanced PAST current_end
+    while reactor.now() is still BEHIND it. Old logic returned True from
+    `_flush_move_in_flight` (because `_move_in_flight()` reads reactor),
+    anchored the next chunk at current_end, and stepcompress saw the
+    new steps land BEFORE its last_step_clock → c=N i=0 crash.
+
+    Hardware-Crash 2026-05-15 klippy.log Z. 12848:
+        current_end=846.893  mcu_now=846.458  step_gen=847.158
+        remaining = current_end - step_gen = -0.265  (NEGATIVE)
+    → next submit must take the fresh-anchor path with
+      anchor = step_gen + lead_time, not anchor = current_end.
+    """
+    printer, feeder = make_feeder()
+    motion_q = printer.lookup_object('motion_queuing')
+    set_sensor_active(feeder, 'hall_empty', True)
+
+    # Hardware-derived state: reactor BEHIND current_end, step_gen AHEAD.
+    feeder.reactor.now = 9.50
+    feeder._continuous_feed = True
+    feeder._continuous_feed_direction = 1
+    feeder._continuous_feed_speed = feeder.feed_speed
+    feeder._last_enable_schedule_time = 8.5
+    feeder._last_move_end_time = 9.85
+    feeder._current_move = {
+        'end_time': 9.85,
+        'direction': 1.0,
+        'distance': feeder.flush_callback_chunk_mm,
+        'speed': feeder.feed_speed,
+    }
+    feeder._stepcompress_primed = True
+
+    # Direct API contract: with step_gen >= current_end, move is done.
+    assert feeder._flush_move_in_flight(step_gen_time=10.20) is False, (
+        "step_gen=10.20 is past current_end=9.85 → move must be reported "
+        "as done. Reactor.now()=9.50 < current_end is irrelevant — only "
+        "step_gen_time is authoritative for stepcompress cursor state.")
+
+    # Boundary case: step_gen exactly at current_end → also done.
+    assert feeder._flush_move_in_flight(step_gen_time=9.85) is False, (
+        "step_gen == current_end must report move done (>= boundary).")
+
+    # End-to-end: trigger flush in the crashing scenario and verify the
+    # submitted anchor lands AHEAD of step_gen, not behind it.
+    appends_before = len(motion_q.append_calls)
+    motion_q.trigger_flush(flush_time=10.18, step_gen_time=10.20)
+
+    own = [c for c in motion_q.append_calls[appends_before:]
+           if c[0] is feeder.trapq]
+    assert own, "expected fresh-anchor submit when step_gen past current_end"
+    t0 = own[0][1]
+    assert t0 >= 10.20, (
+        "anchor t0=%.4f must be >= step_gen_time=10.20 to land after "
+        "stepcompress.last_step_clock and avoid c=N i=0 collapse" % t0)
+
+
 # ---------------------------------------------------------------------------
 # P7-66b — Interrupt-on-HALL via Move-Splitting.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`c5b2e19` (`fix: keep flush streaming on step-gen cursor lag`) löst nur **eine Hälfte** des Cursor-Race in `_flush_move_in_flight`. Die Spiegelung ist ungefixt und triggert dieselbe `stepcompress c=N i=0`-Crash-Family mitten im Druck.

**Hardware-Beleg (klippy.log 2026-05-15 Z. 12848–12851, Diagnose-Build mit zusätzlichen State-Snapshots):**

```
flush_submit_state: anchor=846.893 move_active=True current_end=846.893
                    mcu_now=846.458 step_gen=847.158 remaining=-0.265
                    primed=True en_sched=845.579
trapq_append:       t0=846.893  prev_end=846.893
stepcompress o=0 i=0 c=7 a=0: Invalid sequence
```

`remaining = current_end − step_gen_time = −0.265s` ist **negativ** — der Step-Generator-Cursor sitzt schon 0.265s NACH `current_end`. Trotzdem returnt `_flush_move_in_flight` True (über den `_move_in_flight()`-Branch, weil `reactor.monotonic()` = 846.458 noch VOR `current_end` = 846.893 liegt). Daraus folgt `anchor = current_end`, der Submit landet bei `t0 = 846.893`, das liegt aber bereits VOR `stepcompress.last_step_clock` (~847.158) → 7 Step-Times kollabieren zu Clock=0 → `c=7 i=0`.

## Wurzel

Asymmetrie der Race-Behandlung. `_move_in_flight()` liest `reactor.monotonic()`, kann aber in BEIDEN Richtungen relativ zu `current_end` rennen:

| reactor.now() vs current_end | step_gen vs current_end | Status `_flush_move_in_flight` vor diesem PR | korrekt |
|---|---|---|---|
| < | < | True ✓ | True |
| **<** | **≥** | **True ✗ (Crash)** | **False** |
| ≥ | < | True ✓ (durch c5b2e19) | True |
| ≥ | ≥ | False ✓ | False |

Die zweite Zeile ist die exakte Spiegelung der von `c5b2e19` behandelten dritten Zeile. `step_gen_time` ist die autoritäre Uhr für \"ist der Move aus Stepcompress-Sicht abgeschlossen\" — `reactor.monotonic()` darf das Ergebnis in keiner Richtung beeinflussen.

## Fix

`_flush_move_in_flight` prüft `step_gen_time` **vor** `_move_in_flight()`. Wenn `step_gen_time >= current_end`, Return False unabhängig von `reactor.monotonic()`. Der Cursor-Lag-Pfad (`c5b2e19`) bleibt unverändert für den umgekehrten Fall.

```python
def _flush_move_in_flight(self, step_gen_time):
    if self._current_move is None:
        return False
    current_end = self._current_move.get('end_time', 0.0)
    # NEU: step-gen autoritär — past current_end → move done
    if step_gen_time >= current_end:
        return False
    if self._move_in_flight():
        return True
    # Cursor-Lag (c5b2e19): reactor ahead, step_gen behind
    self._debug_event('flush_cursor_lag', ...)
    return True
```

Hardware-Verifikation: 1h45m-Testdruck mit Fix sauber durchgelaufen, kein einziger `c=N i=0`-Crash (Vergleich: reproduzierbar ohne Fix in ~14 min).

## Begleitende Änderungen

- Neuer Test `test_streaming_returns_done_when_step_gen_past_current_end_and_reactor_behind` in `tests/test_streaming_pipeline_auto.py` — Setup direkt aus den Hardware-Crash-Werten abgeleitet (current_end=9.85, reactor=9.50, step_gen=10.20, erwartet: Submit mit `t0 >= step_gen_time`)
- Bestehender c5b2e19-Test `test_streaming_uses_step_gen_cursor_when_reactor_time_is_ahead` bleibt grün — Cursor-Lag-Pfad nicht angetastet
- Docstring von `_flush_move_in_flight` erweitert: dokumentiert beide Race-Richtungen mit Verweis auf Hardware-Crash und Test-Korrespondenz

Test-Count: 430 → 431, 0 Regressionen, full suite grün.

## Abhängigkeiten

- Basiert auf `c5b2e19` (`fix: keep flush streaming on step-gen cursor lag`, bereits in `refactor/cleanup-all-phases` enthalten)
- Keine API-Änderung
- Keine Konfig-Änderung in `lll.cfg` erforderlich