### PR TITLE
fix(buffer_feeder): Pause-Meldung nur einmal pro Pause (kein Spam)

### DIFF
--- a/klipper_extras/buffer_feeder.py
+++ b/klipper_extras/buffer_feeder.py
@@ -748,6 +748,12 @@ class BufferFeeder:
         # error / standby). Clear the stale lock so next entrance-
         # insert / AUTO_ON_IF_READY proceeds.
         self._bang_bang_suspended = False
+        # Pause-Meldungs-Latch mitraeumen (PR-#49-Review): der
+        # PAUSE->CANCEL-Pfad sieht kein weiteres ready-Event und je
+        # nach Anchor-Gating (hall_full, standby via SDCARD_RESET_FILE)
+        # auch keinen nicht-paused _refresh_print_phase-Tick mehr —
+        # sonst bliebe die erste Pause des naechsten Drucks stumm.
+        self._pause_msg_shown = False
         self._respond("Stale bang-bang-suspend cleared "
                       "(print state=%s)" % ps_state)
         return True
@@ -825,6 +831,46 @@ class BufferFeeder:
             min_interval=0.0)
         return phase
 
+    def _maintain_msg_latches(self, ps_state):
+        """Reset der Meldungs-Dedupe-Latches (PR-#49-Review, Runde 2).
+
+        Der Reset darf NICHT in den idle_timeout-Handlern sitzen:
+        Resume und Anchor-Flap sind im Event-Moment nicht
+        unterscheidbar (beide lesen print_stats.state=='paused', weil
+        note_start deferred im work_handler laeuft), und waehrend des
+        Drucks feuert kein idle_timeout:ready (lookahead busy /
+        gcode-Mutex blocken die Printing->Ready-Transition) — der
+        else-Zweig in _on_idle_ready ist fuer Pause #2+ unerreichbar.
+
+        Aufruf-Stellen (drei Beine, vom Haeufigsten zum Garantierten):
+        1. _refresh_print_phase via Flush-Callback — ABER nur in
+           STATE_AUTO mit Feed-Demand (_flush_submit_streaming_chunk
+           returnt bei target_speed<=0 VOR dem Permission-Check; nach
+           einer Pause ist der Buffer typisch voll -> kein Demand).
+        2. _refresh_print_phase via get_status — Moonraker-Poll,
+           out-of-process (headless/ohne Client-Subscription: nie).
+        3. _main_tick, throttled auf ~1x/s — der in-process
+           GARANTIERTE Anker (Reactor-Timer laeuft immer; er feuert
+           ja auch den Idle-Anchor waehrend der Pause).
+
+        Bekanntes, irreduzibles Fenster: RESUME -> erneute PAUSE
+        innerhalb < 1s ohne dazwischenliegenden Tick laesst den Latch
+        stehen (Meldung der Folge-Pause unterdrueckt, selbstheilend
+        beim naechsten nicht-paused Tick). Event-basiert nicht
+        schliessbar, da Resume im Event-Moment nicht erkennbar ist.
+
+        Siehe test_pause_message_dedupe.py::
+        test_second_pause_announces_via_main_tick_only."""
+        if ps_state != 'paused':
+            self._pause_msg_shown = False
+        if ps_state in ('printing', 'paused'):
+            # Laufender/pausierter Druck: Print-ended-Latch freigeben,
+            # damit das Ende DIESES Drucks wieder gemeldet wird.
+            # 'complete'/'standby' resetten bewusst NICHT — die Post-
+            # Print-Flaps lesen genau diese States und wuerden den
+            # Print-ended-Spam reaktivieren.
+            self._print_end_msg_shown = False
+
     def _refresh_print_phase(self, eventtime=None):
         if eventtime is None:
             eventtime = self.reactor.monotonic()
@@ -834,6 +880,11 @@ class BufferFeeder:
 
         if ps_state == 'printing' and active_extrusion:
             self._print_extrusion_seen = True
+
+        # Meldungs-Latch-Wartung am Phase-Refresh (Flush-Pfad mit
+        # Feed-Demand + get_status-Poll) — Haupt-Garantie liegt im
+        # _main_tick, siehe _maintain_msg_latches-Docstring.
+        self._maintain_msg_latches(ps_state)
 
         if ps_state == 'paused':
             return self._set_print_phase(
@@ -901,8 +952,34 @@ class BufferFeeder:
                 if self._continuous_feed:
                     self._continuous_feed = False
                     self._halt_motion()
-                self._respond("Print paused — bang-bang suspended until RESUME")
+                # Meldung nur EINMAL pro Pause (Spam-Fix 2026-06-10,
+                # Hardware klippy.log: 564x dieselbe Zeile in einer
+                # Pause). Waehrend der Pause feuert idle_timeout:ready
+                # alle ~10s erneut, weil der Buffer-eigene Idle-Anchor-
+                # Move (idle_anchor_gap, noetig gegen stepcompress-Clock-
+                # Drift) ueber toolhead:sync_print_time Klippers
+                # idle_timeout printing->ready kippt. Der Anchor laesst
+                # sich nicht abstellen, und _on_idle_printing gegen
+                # 'paused' zu guarden waere unsicher (echtes RESUME
+                # feuert idle_timeout:printing ebenfalls bei print_stats
+                # =='paused', weil note_start deferred im work_handler
+                # laeuft → wuerde den Resume-Trigger mit-unterdruecken).
+                # Daher Dedupe nur auf Meldungs-Ebene; die Suspend-Logik
+                # oben bleibt idempotent pro Zyklus. Latch-RESET sitzt
+                # in _refresh_print_phase (ps_state != 'paused' am
+                # Flush-/Statuspoll-Tick) — NICHT im else-Zweig unten,
+                # der waehrend eines laufenden Drucks nie erreicht wird
+                # (PR-#49-Review Must-fix 1) — plus PAUSE->CANCEL-
+                # Heilung in _clear_stale_suspend_if_print_inactive.
+                if not self._pause_msg_shown:
+                    self._respond(
+                        "Print paused — bang-bang suspended until RESUME")
+                    self._pause_msg_shown = True
             else:
+                # Nicht-paused ready (Druckende complete/standby oder
+                # Anchor-Flap nach Druckende): Pause-Latch defensiv
+                # zuruecksetzen (Haupt-Reset siehe _refresh_print_phase).
+                self._pause_msg_shown = False
                 self._set_benchmark_mode(False, reason='print_ready', notify=False)
                 self._print_extrusion_seen = False
                 self._critical_action_guard_until = 0.0
@@ -919,8 +996,20 @@ class BufferFeeder:
                 # auto-grip. _bang_bang_suspended stays whatever it
                 # was (operator may have set it explicitly via
                 # BUFFER_AUTO_OFF; we don't override).
-                self._respond("Print ended — buffer ready for next "
-                              "filament change or print")
+                #
+                # Meldung gelatcht (PR-#49-Review Should-fix): bei
+                # state='complete'/'cancelled' greift der nur-'standby'-
+                # Fruehausstieg in _on_idle_printing nicht — derselbe
+                # Anchor-Flap wie im Pause-Fall wuerde die Zeile sonst
+                # alle ~10s wiederholen, solange der Drucker so steht
+                # (z.B. wenn park_full_on_print_end nicht greift).
+                # Latch-Reset in _refresh_print_phase bei printing/paused.
+                if not self._print_end_msg_shown:
+                    self._respond("Print ended — buffer ready for next "
+                                  "filament change or print")
+                    self._print_end_msg_shown = True
+                # Park-Hook bleibt ausserhalb des Meldungs-Latches —
+                # er hat sein eigenes Once-Gate (_park_full_attempted).
                 self._maybe_park_full_on_print_end(now, ps_state)
         self._print_running = False
 
@@ -1287,6 +1376,16 @@ class BufferFeeder:
             # learn the real hardware picture.
             if not self._startup_grace_done:
                 return eventtime + MAIN_TICK_INTERVAL
+
+            # Meldungs-Latch-Wartung, throttled auf ~1x/s (Tick laeuft
+            # 50Hz; ein print_stats.get_status pro Sekunde ist billig).
+            # In-process garantierter Reset-Anker — Flush-Pfad und
+            # get_status-Poll sind beide konditional, siehe
+            # _maintain_msg_latches-Docstring.
+            if eventtime >= self._last_msg_latch_maint + 1.0:
+                self._last_msg_latch_maint = eventtime
+                self._maintain_msg_latches(
+                    self._get_print_stats_state(eventtime))
 
             # C-cont T6: HALL1-Persist-Check. In STATE_AUTO loest HALL1-
             # Edge nicht mehr direkt _enter_overflow aus (siehe T5). Erst
@@ -4481,6 +4580,13 @@ class BufferFeeder:
 
     def cmd_ENABLE_RUNOUT_SENSOR(self, gcmd):
         self._print_running = True
+        # Bench-Re-Arm (Review Runde 2): auf einem Rig das nie via
+        # virtual_sdcard druckt, erreicht print_stats nie
+        # 'printing'/'paused' — der Print-ended-Latch wuerde nach der
+        # ersten Bench-Session fuer immer haengen. Manuelles Armen von
+        # _print_running ist der Session-Start-Marker, also hier mit
+        # freigeben.
+        self._print_end_msg_shown = False
         self._respond("print_running=1 (runout PAUSE will fire)")
 
     def cmd_DISABLE_RUNOUT_SENSOR(self, gcmd):

--- a/klipper_extras/buffer_state.py
+++ b/klipper_extras/buffer_state.py
@@ -64,6 +64,9 @@ class BufferRuntimeState:
     _measure_load_distance: float = 0.0
     _measure_feeding: bool = False
     _print_running: bool = False
+    _pause_msg_shown: bool = False  # Dedupe-Latch Pause-Meldung (siehe _maintain_msg_latches)
+    _print_end_msg_shown: bool = False  # Dedupe-Latch Print-ended-Meldung (siehe _maintain_msg_latches)
+    _last_msg_latch_maint: float = 0.0  # Throttle-Watermark Latch-Wartung in _main_tick (~1x/s)
     _benchmark_mode_until: float = 0.0
     _benchmark_mode_reason: str = ""
     _print_phase: str = "inactive"

--- a/tests/test_pause_message_dedupe.py
+++ b/tests/test_pause_message_dedupe.py
@@ -1,0 +1,275 @@
+"""Pause-/Print-ended-Meldungen duerfen nur EINMAL pro Episode
+erscheinen, nicht im 10s-Takt gespammt.
+
+Hardware-Beleg 2026-06-10 klippy.log: Waehrend einer durch den
+encoder_sensor ausgeloesten PAUSE erschien
+``BufferFeeder: Print paused — bang-bang suspended until RESUME``
+1128 Mal (564 logisch, alle ~10s).
+
+Wurzel (verifiziert gegen Klipper-Core idle_timeout.py + virtual_-
+sdcard.py): Der Buffer feuert waehrend der Pause alle 10s seinen
+Idle-Anchor-Move (idle_anchor_gap, noetig gegen stepcompress-Clock-
+Drift). Jeder Anchor bumpt ueber ``toolhead:sync_print_time`` Klippers
+idle_timeout-Statemachine printing->ready. Dadurch feuern
+``idle_timeout:printing`` (_on_idle_printing) und ``idle_timeout:ready``
+(_on_idle_ready) alle 10s erneut; _on_idle_ready sendete die Pause-
+Meldung bei jedem Durchlauf.
+
+Fix-Architektur (PR-Review-Runde 2):
+- Meldung wird in _on_idle_ready per Latch ``_pause_msg_shown``
+  dedupliziert (einmal pro Pause-Episode).
+- Der Latch-RESET sitzt NICHT in den idle_timeout-Handlern: Resume
+  und Anchor-Flap sind im Event-Moment nicht unterscheidbar (beide
+  lesen print_stats.state=='paused', weil note_start deferred im
+  work_handler-Timer laeuft). Ein Reset dort wuerde entweder den
+  Resume-Trigger mit-unterdruecken oder bei jedem Flap re-armen.
+- Stattdessen Reset in _refresh_print_phase sobald ps_state !=
+  'paused' gelesen wird. Dieser Pfad laeuft in der Realitaet
+  garantiert: via _auto_submit_permission bei jedem Flush-Callback
+  UND via get_status bei jedem Moonraker-Statuspoll (~1x/s). Die
+  Tests simulieren diesen Tick explizit (siehe _flush_tick).
+- PAUSE->CANCEL (kein ready-Event mehr): _clear_stale_suspend_if_-
+  print_inactive raeumt den Latch zusammen mit dem Suspend-Flag.
+
+Should-fix derselben Klasse: ``Print ended — buffer ready ...`` haengt
+am identischen Flap (bei state='complete'/'cancelled' greift der nur-
+'standby'-Fruehausstieg in _on_idle_printing nicht) und bekommt
+denselben Latch (``_print_end_msg_shown``), Reset bei printing/paused.
+"""
+
+from fakes_klipper import FakeConfig, FakePrinter, FakePrintStats
+from klipper_extras import buffer_feeder
+
+
+PAUSE_MSG_FRAGMENT = "bang-bang suspended until RESUME"
+END_MSG_FRAGMENT = "Print ended"
+
+
+def make_feeder(values=None):
+    printer = FakePrinter()
+    config = FakeConfig(printer=printer, values=values)
+    feeder = buffer_feeder.BufferFeeder(config)
+    # Enable-Pfad verdrahten, damit Faelle mit _continuous_feed/
+    # _halt_motion (Review-Nit PR #49) ohne Setup-Drift ergaenzbar sind.
+    printer.fire_event('klippy:connect')
+    feeder._startup_grace_done = True
+    feeder._state = buffer_feeder.STATE_AUTO  # kein JAM/auto-engage in _on_idle_printing
+    return printer, feeder
+
+
+def _msgs(printer, fragment):
+    gc = printer.objects['gcode']
+    return [m for m in gc.info_messages if fragment in m]
+
+
+def _flush_tick(feeder):
+    """Ein Flush-/Statuspoll-Tick. In der Realitaet laeuft
+    _refresh_print_phase kontinuierlich: via _auto_submit_permission
+    bei jedem _on_mcu_flush-Callback und via get_status bei jedem
+    Moonraker-Poll (~1x/s, auch waehrend Pause — siehe
+    flush_skip_permission-Events im Hardware-Log 2026-06-10)."""
+    feeder._refresh_print_phase(feeder.reactor.monotonic())
+
+
+def _simulate_pause_cycle(feeder):
+    """Ein 10s-Anchor-Zyklus waehrend einer Pause: idle_timeout kippt
+    printing->ready, dazwischen/danach laufen Flush-/Statuspoll-Ticks
+    mit ps_state='paused'. Reproduziert die echte Event-Reihenfolge."""
+    feeder._on_idle_printing()  # idle_timeout:printing (state='paused'!)
+    feeder._on_idle_ready()     # idle_timeout:ready (Pause-Branch)
+    _flush_tick(feeder)         # Poll-Tick liest 'paused' -> darf NICHT resetten
+
+
+def test_pause_message_emitted_once_across_repeated_idle_ready():
+    """Sechs Anchor-Zyklen (inkl. Flush-Ticks) waehrend EINER Pause
+    -> genau EINE Meldung."""
+    printer, feeder = make_feeder()
+    printer.objects['print_stats'] = FakePrintStats(state='paused')
+
+    for _ in range(6):
+        _simulate_pause_cycle(feeder)
+
+    msgs = _msgs(printer, PAUSE_MSG_FRAGMENT)
+    assert len(msgs) == 1, (
+        "Pause-Meldung soll genau einmal pro Pause erscheinen, "
+        "war aber %d mal da: %s" % (len(msgs), msgs))
+
+
+def test_second_pause_of_same_print_announces_again():
+    """Maintainer-Review Must-fix 1 (PR #49): Pause #2 desselben Drucks
+    muss wieder gemeldet werden. Echte Event-Sequenz: beim RESUME feuert
+    nur idle_timeout:printing (waehrend print_stats noch 'paused' ist,
+    note_start deferred im work_handler); KEIN idle_timeout:ready bis
+    zur naechsten Pause (lookahead busy / gcode-Mutex blockt die
+    Printing->Ready-Transition waehrend des Drucks)."""
+    printer, feeder = make_feeder()
+    ps = FakePrintStats(state='paused')
+    printer.objects['print_stats'] = ps
+
+    # ---- Pause 1: drei Anchor-Flaps ----
+    for _ in range(3):
+        _simulate_pause_cycle(feeder)
+    assert len(_msgs(printer, PAUSE_MSG_FRAGMENT)) == 1
+
+    # ---- Echtes RESUME ----
+    # idle_timeout:printing feuert waehrend print_stats noch 'paused'
+    # ist (note_start deferred im work_handler).
+    feeder._on_idle_printing()
+    ps.state = 'printing'
+    # Druck laeuft kontinuierlich: KEIN idle_timeout:ready bis zur
+    # naechsten Pause — aber Flush-Callbacks und Moonraker-Statuspolls
+    # laufen weiter und lesen jetzt 'printing'.
+    _flush_tick(feeder)
+
+    # ---- Pause 2 desselben Drucks ----
+    ps.state = 'paused'
+    for _ in range(3):
+        _simulate_pause_cycle(feeder)
+
+    assert len(_msgs(printer, PAUSE_MSG_FRAGMENT)) == 2, (
+        "Pause #2 desselben Drucks muss wieder gemeldet werden")
+
+
+def test_pause_cancel_heals_latch_for_next_print():
+    """PAUSE -> CANCEL: kein weiteres ready-Event (idle_timeout bleibt
+    in Ready). _clear_stale_suspend_if_print_inactive heilt den Suspend
+    lazy — und muss den Pause-Latch mitraeumen, sonst bleibt die erste
+    Pause des NAECHSTEN Drucks stumm."""
+    printer, feeder = make_feeder()
+    ps = FakePrintStats(state='paused')
+    printer.objects['print_stats'] = ps
+
+    # Pause mit Meldung
+    _simulate_pause_cycle(feeder)
+    assert len(_msgs(printer, PAUSE_MSG_FRAGMENT)) == 1
+
+    # CANCEL statt RESUME — lazy-heal laeuft an einem Decision-Point
+    ps.state = 'cancelled'
+    cleared = feeder._clear_stale_suspend_if_print_inactive(
+        feeder.reactor.monotonic())
+    assert cleared is True
+
+    # Naechster Druck, erste Pause -> muss wieder melden
+    ps.state = 'paused'
+    feeder._print_running = True
+    feeder._on_idle_ready()
+
+    assert len(_msgs(printer, PAUSE_MSG_FRAGMENT)) == 2, (
+        "Erste Pause des naechsten Drucks nach PAUSE->CANCEL muss "
+        "gemeldet werden")
+
+
+def test_second_pause_announces_via_main_tick_only():
+    """Adversarial-Review-Befund (Runde 2): Der Flush-Pfad erreicht
+    _refresh_print_phase NUR in STATE_AUTO mit Feed-Demand — nach einer
+    Pause ist der Buffer typisch voll (hall_full -> target_speed=0) und
+    _flush_submit_streaming_chunk returnt VOR dem Permission-Check.
+    get_status haengt am Moonraker-Poll (out-of-process, headless ggf.
+    nie). Der Latch-Reset braucht daher einen in-process garantierten
+    Anker: _main_tick (50Hz-Reactor-Timer, laeuft immer — feuert ja
+    auch den Anchor waehrend der Pause), throttled auf ~1x/s.
+
+    Szenario: Resume ohne JEDEN Flush-/Statuspoll-Tick — nur
+    _main_tick laeuft. Pause #2 muss trotzdem melden."""
+    printer, feeder = make_feeder()
+    ps = FakePrintStats(state='paused')
+    printer.objects['print_stats'] = ps
+
+    # Pause 1
+    for _ in range(3):
+        feeder._on_idle_printing()
+        feeder._on_idle_ready()
+    assert len(_msgs(printer, PAUSE_MSG_FRAGMENT)) == 1
+
+    # Echtes RESUME (idle_timeout:printing liest noch 'paused'),
+    # danach laeuft NUR der Reactor-Tick — kein Flush, kein get_status.
+    feeder._on_idle_printing()
+    ps.state = 'printing'
+    feeder.reactor.now = 50.0
+    feeder._main_tick(eventtime=50.0)
+
+    # Pause 2
+    ps.state = 'paused'
+    for _ in range(3):
+        feeder._on_idle_printing()
+        feeder._on_idle_ready()
+
+    assert len(_msgs(printer, PAUSE_MSG_FRAGMENT)) == 2, (
+        "Pause #2 muss auch ohne Flush-Demand/Moonraker-Poll gemeldet "
+        "werden — _main_tick ist der in-process garantierte Reset-Anker")
+
+
+def test_main_tick_during_pause_keeps_latch():
+    """Gegenprobe: _main_tick liest waehrend der Pause 'paused' und
+    darf den Latch NICHT freigeben (sonst kehrt der 10s-Spam zurueck)."""
+    printer, feeder = make_feeder()
+    printer.objects['print_stats'] = FakePrintStats(state='paused')
+
+    feeder._on_idle_printing()
+    feeder._on_idle_ready()
+    for t in (50.0, 52.0, 54.0):
+        feeder.reactor.now = t
+        feeder._main_tick(eventtime=t)
+        feeder._on_idle_printing()
+        feeder._on_idle_ready()
+
+    assert len(_msgs(printer, PAUSE_MSG_FRAGMENT)) == 1, (
+        "Tick waehrend der Pause darf den Dedupe-Latch nicht aufheben")
+
+
+def test_pause_suspends_bangbang_on_every_cycle_despite_dedupe():
+    """Regressions-Schutz: Der Dedupe-Latch darf NUR die Meldung
+    unterdruecken, nicht die Suspend-Logik. _bang_bang_suspended muss
+    nach jedem Pause-ready True sein (sonst koennte ein Feed durch-
+    rutschen)."""
+    printer, feeder = make_feeder()
+    printer.objects['print_stats'] = FakePrintStats(state='paused')
+
+    for _ in range(3):
+        _simulate_pause_cycle(feeder)
+        assert feeder._bang_bang_suspended is True, (
+            "Suspend-Flag muss nach jedem Pause-ready gesetzt sein")
+
+
+def test_print_end_message_emitted_once_across_flaps():
+    """Should-fix (PR-#49-Review): Nach Druckende (state='complete')
+    passiert der Anchor-Flap den nur-'standby'-Guard in
+    _on_idle_printing -> "Print ended"-Meldung spammte im selben
+    10s-Muster. Gleicher Latch, gleches Einmal-Verhalten."""
+    printer, feeder = make_feeder()
+    printer.objects['print_stats'] = FakePrintStats(state='complete')
+
+    for _ in range(5):
+        feeder._on_idle_printing()  # 'complete' != 'standby' -> kein Fruehausstieg
+        feeder._on_idle_ready()
+        _flush_tick(feeder)
+
+    msgs = _msgs(printer, END_MSG_FRAGMENT)
+    assert len(msgs) == 1, (
+        "Print-ended-Meldung soll genau einmal erscheinen, "
+        "war aber %d mal da: %s" % (len(msgs), msgs))
+
+
+def test_print_end_message_reannounced_after_next_print():
+    """Latch-Reset fuer die Print-ended-Meldung: ein neuer Druck
+    (ps_state='printing' am Flush-/Poll-Tick) gibt den Latch frei,
+    das Ende des naechsten Drucks wird wieder gemeldet."""
+    printer, feeder = make_feeder()
+    ps = FakePrintStats(state='complete')
+    printer.objects['print_stats'] = ps
+
+    feeder._print_running = True
+    feeder._on_idle_ready()
+    assert len(_msgs(printer, END_MSG_FRAGMENT)) == 1
+
+    # Neuer Druck laeuft an
+    ps.state = 'printing'
+    feeder._on_idle_printing()
+    _flush_tick(feeder)
+
+    # Druck #2 endet
+    ps.state = 'complete'
+    feeder._on_idle_ready()
+
+    assert len(_msgs(printer, END_MSG_FRAGMENT)) == 2, (
+        "Ende des naechsten Drucks muss wieder gemeldet werden")


### PR DESCRIPTION
## Problem

Während einer PAUSE wird die Konsole zugespammt mit
`BufferFeeder: Print paused — bang-bang suspended until RESUME` —
4-6× pro Minute. Hardware-Beleg 2026-06-10 (`klippy.log`): die Zeile
erschien **1128 Mal** (564 logisch, ~alle 10s) in einer einzigen Pause.

Wurzel (verifiziert gegen Klipper-Core `idle_timeout.py` +
`virtual_sdcard.py`):

Der Buffer feuert während der Pause alle 10s seinen Idle-Anchor-Move
(`idle_anchor_gap`, nötig gegen stepcompress-Clock-Drift, Issue #12).
Jeder Anchor bumpt über `toolhead:sync_print_time` Klippers
`idle_timeout`-Statemachine printing→ready (`handle_sync_print_time`).
Dadurch feuern `idle_timeout:printing` (`_on_idle_printing`) und
`idle_timeout:ready` (`_on_idle_ready`) alle 10s erneut, und
`_on_idle_ready` sendet die Pause-Meldung bei jedem Durchlauf erneut.
Die Annahme im Kommentar an `_clear_stale_suspend_if_print_inactive`
(_„idle_timeout:ready only fires once per printing→ready transition"_)
gilt nicht, weil der Buffer **selbst** printing→ready-Übergänge erzeugt.

## Fix

Dedupe-Latch `_pause_msg_shown` in `_on_idle_ready`: die Meldung wird
nur beim ersten Eintritt in die Pause gesendet; der Latch wird im
else-Zweig (nicht-paused ready = Resume/Druckende) zurückgesetzt,
damit die nächste echte Pause wieder gemeldet wird.

Die Suspend-/State-Logik bleibt **unangetastet**. Bewusst NICHT
gefixt: das Unterdrücken der anchor-getriebenen printing/ready-Events
selbst. Beim echten RESUME feuert `idle_timeout:printing` während
`print_stats.state` noch `'paused'` ist (`note_start` läuft deferred
im `work_handler`-Timer auf `reactor.NOW`), ist im Moment des Feuerns
also nicht von einem Anchor-Event unterscheidbar. Ein Guard von
`_on_idle_printing` gegen `'paused'` würde den echten Resume-Trigger
mit-unterdrücken → `_bang_bang_suspended` bliebe True →
Filament-Starvation. Empirisch im Log bestätigt.

## Begleitende Änderungen

- `tests/test_pause_message_dedupe.py`: 3 neue Tests
  (1× Meldung pro Pause; Re-Announce nach Resume; Suspend-Logik bleibt
  pro Zyklus erhalten).
- Test-Count: 515 → 518 passed, 8 skipped, 0 Regressionen.

## Abhängigkeiten

Keine. Basiert auf `refactor/cleanup-all-phases` HEAD (`63a3d85`).
