### PR TITLE
diag(buffer_feeder): Anchor-vs-Queue Instrumentierung fuer Issue #50 (NICHT Production)

### DIFF
--- a/klipper_extras/buffer_feeder.py
+++ b/klipper_extras/buffer_feeder.py
@@ -2954,6 +2954,23 @@ class BufferFeeder:
         was_primed = self._stepcompress_primed
         need_reprime = self._reprime_stepcompress_if_needed(forced_t0, gap)
 
+        # Diagnose-Build Issue #50 (Regel #11a, NICHT Production).
+        # Voller Anchor-Input-State am Submit + Queue-Ende. min_interval=
+        # 0.0 damit im OVERFLOW↔LOAD-Sturm keine Events verloren gehen.
+        cur_end = (self._current_move.get('end_time')
+                   if self._current_move is not None else None)
+        self._debug_event(
+            'diag_submit',
+            "state=%s dist=%.3f speed=%.3f forced_t0=%s streaming=%s "
+            "mcu_now=%.6f lme=%.6f en=%.6f gap=%+.6f was_primed=%s "
+            "need_reprime=%s cur_end=%s",
+            self._state, signed_distance, speed,
+            ("%.6f" % forced_t0) if forced_t0 is not None else "None",
+            streaming, mcu_now, self._last_move_end_time,
+            self._last_enable_schedule_time, gap, was_primed, need_reprime,
+            ("%.6f" % cur_end) if cur_end is not None else "None",
+            min_interval=0.0)
+
         # Skip motor-enable in streaming lookahead — previous chunk
         # already enabled the motor and pushed _last_enable_schedule_-
         # time forward. skip_enable additionally suppresses enable for
@@ -3096,6 +3113,16 @@ class BufferFeeder:
         toolhead = self.printer.lookup_object('toolhead')
         th_time = toolhead.get_last_move_time()
         t0 = max(th_time + self.lead_time, self._last_move_end_time, en)
+        # Diagnose-Build Issue #50 (Regel #11a, NICHT Production). th_time
+        # ist die Anchor-Quelle im Recovery-Pfad. Wenn sie unter Tight-
+        # Cycling hinter dem buffer-eigenen Queue-Ende lagged, landet t0
+        # hinter der Queue -> i=0-Crash. min_interval=0.0 (Sturm).
+        self._debug_event(
+            'diag_anchor',
+            "firstchunk th_time=%.6f lead=%.6f lme=%.6f en=%.6f "
+            "mcu_now=%.6f t0=%.6f t0-th=%+.6f",
+            th_time, self.lead_time, self._last_move_end_time, en, mcu_now,
+            t0, t0 - th_time, min_interval=0.0)
         if t0 > mcu_now + MAX_T0_LOOKAHEAD_S:
             # th_time is far ahead (active print with filled toolhead
             # queue). Clamping to mcu_now would land BEFORE
@@ -3147,6 +3174,25 @@ class BufferFeeder:
 
     def _append_trapezoid_and_record(self, t0, signed_distance, speed):
         """Compute the trapezoid profile, append to trapq, update state."""
+        # Diagnose-Build Issue #50 (Regel #11a, NICHT Production). Direkt
+        # vor trapq_append: finaler t0 gegen lme und cur_end (= noch
+        # gequeuete Steps des von halt_motion getrunkten Vorgänger-
+        # Chunks). t0-curend < 0 ist der direkte Beleg "Submit landet
+        # hinter der Queue" -> i=0 c=N stepcompress-Crash.
+        _cur_end = (self._current_move.get('end_time')
+                    if self._current_move is not None else None)
+        _mcu = self.stepper.get_mcu()
+        _mcu_now = _mcu.estimated_print_time(self.reactor.monotonic())
+        self._debug_event(
+            'diag_append',
+            "t0=%.6f lme_in=%.6f cur_end=%s mcu_now=%.6f t0-lme=%+.6f "
+            "t0-curend=%s commanded_pos=%.3f",
+            t0, self._last_move_end_time,
+            ("%.6f" % _cur_end) if _cur_end is not None else "None",
+            _mcu_now, t0 - self._last_move_end_time,
+            ("%+.6f" % (t0 - _cur_end)) if _cur_end is not None else "None",
+            self._commanded_pos, min_interval=0.0)
+
         distance = abs(signed_distance)
         direction = 1.0 if signed_distance > 0 else -1.0
 

--- a/tests/test_diag_load_overflow.py
+++ b/tests/test_diag_load_overflow.py
@@ -1,0 +1,139 @@
+"""Diagnose-Build (Regel #11a, NICHT Production) für Issue #50.
+
+Hardware-Crash 2026-06-12 klippy.log Z.50622: ``stepcompress o=0 i=0
+c=10 a=0: Invalid sequence`` auf dem Buffer-Stepper während eines
+rapiden OVERFLOW↔LOAD_PHASE_1-Cyclings (HALL1 durch SFS-V2-Gegendruck).
+
+Der queue_step-Dump (Z.51477-51498) zeigt eine valide Trapez-Queue —
+der Crash trat beim HINZUFÜGEN der nächsten Step-Charge auf, deren
+Clock bei/hinter dem Queue-Ende landet (Anchor-hinter-Queue,
+Issue-#29-Klasse). Der laufende Code hat keine Submit-Diagnose-Events;
+WARUM der Anchor unter dem Cycling hinter die Queue fällt, ist
+unbewiesen.
+
+Diese Events capturen am Submit den finalen ``t0`` gegen
+``_current_move['end_time']`` (= die noch gequeueten Steps des von
+halt_motion getrunkten Vorgänger-Chunks). t0 < cur_end ist der direkte
+Beleg für "Submit landet hinter der Queue". min_interval=0.0 damit im
+Sturm keine Events verloren gehen.
+
+Nach bewiesener Wurzel: per git revert zurücknehmen.
+"""
+
+import logging
+
+from klipper_extras import buffer_feeder
+
+
+def _enable_diag(feeder):
+    feeder.buffer_debug_events = True
+    feeder._startup_grace_done = True
+
+
+def test_submit_emits_diag_submit_with_anchor_inputs(feeder, monkeypatch,
+                                                     caplog):
+    """diag_submit am Submit-Eingang: kompletter Anchor-Input-State
+    inkl. _current_move['end_time'] (Queue-Ende) und Reprime-Entscheidung."""
+    _enable_diag(feeder)
+    monkeypatch.setattr(feeder, "trapq_append", lambda *a, **k: None)
+    monkeypatch.setattr(feeder, "_reprime_stepcompress_if_needed",
+                        lambda forced_t0, gap: False)
+    monkeypatch.setattr(feeder, "_enable_stepper", lambda: None)
+    feeder._current_move = {'end_time': 1234.5}
+
+    with caplog.at_level(logging.INFO, logger=""):
+        feeder._submit_single_trapezoid(50.0, 50.0,
+                                        forced_t0=None, streaming=False)
+
+    msgs = [r.getMessage() for r in caplog.records]
+    diag = [m for m in msgs if "diag_submit" in m]
+    assert diag, "diag_submit-Event fehlt. Alle: %s" % msgs
+    for field in ("state=", "dist=", "speed=", "forced_t0=", "streaming=",
+                  "mcu_now=", "lme=", "en=", "gap=", "was_primed=",
+                  "need_reprime=", "cur_end="):
+        assert field in diag[0], "Feld '%s' fehlt: %s" % (field, diag[0])
+
+
+def test_append_emits_diag_append_with_t0_vs_queue(feeder, monkeypatch,
+                                                   caplog):
+    """diag_append direkt vor trapq_append: finaler t0 gegen lme und
+    cur_end (Queue-Ende) — die kritischen Deltas, die "hinter der Queue"
+    beweisen."""
+    _enable_diag(feeder)
+    monkeypatch.setattr(feeder, "trapq_append", lambda *a, **k: None)
+    feeder._current_move = {'end_time': 999.0}
+    feeder._last_move_end_time = 10.0
+
+    with caplog.at_level(logging.INFO, logger=""):
+        feeder._append_trapezoid_and_record(42.0, 50.0, 50.0)
+
+    msgs = [r.getMessage() for r in caplog.records]
+    diag = [m for m in msgs if "diag_append" in m]
+    assert diag, "diag_append-Event fehlt. Alle: %s" % msgs
+    for field in ("t0=", "lme_in=", "cur_end=", "mcu_now=",
+                  "t0-lme=", "t0-curend="):
+        assert field in diag[0], "Feld '%s' fehlt: %s" % (field, diag[0])
+
+
+def test_diag_append_reports_t0_behind_queue_delta(feeder, monkeypatch,
+                                                   caplog):
+    """Kernbeweis-Fähigkeit: wenn t0 < cur_end, muss t0-curend negativ
+    sein (Submit landet hinter der noch gequeueten Bewegung)."""
+    _enable_diag(feeder)
+    monkeypatch.setattr(feeder, "trapq_append", lambda *a, **k: None)
+    feeder._current_move = {'end_time': 100.0}
+    feeder._last_move_end_time = 5.0
+
+    with caplog.at_level(logging.INFO, logger=""):
+        feeder._append_trapezoid_and_record(30.0, 50.0, 50.0)  # t0=30 < 100
+
+    diag = [r.getMessage() for r in caplog.records if "diag_append" in r.getMessage()]
+    assert diag, "diag_append fehlt"
+    # t0-curend = 30 - 100 = -70 -> negatives Delta muss sichtbar sein
+    assert "t0-curend=-70.0" in diag[0] or "t0-curend=-70" in diag[0], (
+        "negatives t0-curend-Delta nicht korrekt geloggt: %s" % diag[0])
+
+
+def test_plan_anchor_emits_diag_anchor_with_th_time(feeder, caplog):
+    """diag_anchor im First-Chunk/Recovery-Pfad: th_time
+    (toolhead.get_last_move_time() = die Anchor-Quelle) gegen den
+    berechneten t0. Damit sehen wir, ob der Recovery-Anchor unter
+    Tight-Cycling hinter die Queue lappt (th_time lagged).
+
+    Hardware-Befund 2026-06-12 (gesunder Lauf): Recovery-Submits hatten
+    t0-curend=+0.14; der Crash-Lauf cyclete tighter. th_time ist der
+    fehlende Wert zwischen Anchor-Quelle und Queue-Ende."""
+    _enable_diag(feeder)
+    feeder.printer.objects['toolhead'].last_move_time = 100.0
+    feeder._last_move_end_time = 0.0
+    feeder._last_enable_schedule_time = 0.0
+
+    with caplog.at_level(logging.INFO, logger=""):
+        # First-Chunk-Pfad: forced_t0=None, lme(0) <= mcu_now+lead,
+        # streaming=False -> _plan_t0_anchor liest th_time.
+        t0 = feeder._compute_t0_anchor(
+            None, 100.0, was_primed=False, need_reprime=True,
+            streaming=False)
+
+    assert t0 is not None
+    diag = [r.getMessage() for r in caplog.records if "diag_anchor" in r.getMessage()]
+    assert diag, "diag_anchor-Event fehlt"
+    for field in ("th_time=", "lead=", "lme=", "en=", "mcu_now=", "t0=",
+                  "t0-th="):
+        assert field in diag[0], "Feld '%s' fehlt: %s" % (field, diag[0])
+    assert "th_time=100.0" in diag[0], (
+        "th_time falsch geloggt: %s" % diag[0])
+
+
+def test_diag_events_off_when_debug_disabled(feeder, monkeypatch, caplog):
+    """Ohne buffer_debug_events: keine diag-Events (Production-no-op)."""
+    feeder.buffer_debug_events = False
+    feeder._startup_grace_done = True
+    monkeypatch.setattr(feeder, "trapq_append", lambda *a, **k: None)
+
+    with caplog.at_level(logging.INFO, logger=""):
+        feeder._append_trapezoid_and_record(42.0, 50.0, 50.0)
+
+    msgs = [r.getMessage() for r in caplog.records]
+    assert not [m for m in msgs if "diag_append" in m], (
+        "diag-Events dürfen bei buffer_debug_events=False nicht feuern")


### PR DESCRIPTION
**Diagnose-Instrumentierung, KEIN Fix.** Zweck: die Wurzel des
stepcompress-Crashes aus #50 festnageln, bevor ein Fix entschieden
wird. Bewusst als PR geteilt, damit du (mit dem tieferen stepcompress-
Wissen) selbst reproduzieren/mitlesen kannst.

## Was es tut

Drei Events, alle gated durch `buffer_debug_events`, `min_interval=0.0`
(damit im OVERFLOW↔LOAD-Sturm keine Events verloren gehen). Keine
Änderung an Motion-/State-Logik:

- **`diag_submit`** (`_submit_single_trapezoid`): kompletter Anchor-
  Input-State + Reprime-Entscheidung + `_current_move['end_time']`.
- **`diag_anchor`** (`_plan_t0_anchor`, First-Chunk/Recovery-Pfad):
  `th_time` (`toolhead.get_last_move_time()` = Anchor-Quelle) gegen t0.
- **`diag_append`** (`_append_trapezoid_and_record`, direkt vor
  `trapq_append`): finaler t0 gegen `lme` und `cur_end`.
  **`t0-curend < 0` = direkter Beleg „Submit landet hinter der Queue".**

## Erste Hardware-Daten (gesunder Lauf 2026-06-12, 8 Overflow-Zyklen, KEIN Crash)

- `t0-curend` blieb durchweg ≥ 0 (Recovery-Submits **+0.14**,
  Streaming-Abut **exakt +0.000000**).
- Der **Streaming-Abut-Pfad läuft bei `t0-curend == 0`** (Nullmarge) —
  die fragile Stelle.
- Dieser Lauf hatte eine **14s-Pause** zwischen Zyklen; der Crash-Lauf
  cyclete **tight back-to-back (~1-2/s)**. Stark timing-sensitiv.

Der negative `t0-curend` am Crash ist noch nicht eingefangen (der
Repro-Lauf hielt). Mit der Instrumentierung live fängt der nächste
echte Crash die Smoking-Gun-Werte (th_time-Lag → t0 hinter Queue).

## Tests / Scope

`tests/test_diag_load_overflow.py` (5 Tests). Full-Suite 543 passed,
8 skipped, 0 Regressionen.

## Hinweis zum Mergen

Reine Diagnose — sinnvoll nur solange #50 offen ist. Nach bewiesener
Wurzel per `git revert` zurücknehmbar. Basiert auf
`refactor/cleanup-all-phases` HEAD (`4c91cfb`). Bezug: #50.
