### PR TITLE
feat: 5°C-Temperaturfenster beim LOAD/UNLOAD-Aufheizen

### DIFF
--- a/klipper_extras/buffer_feeder.py
+++ b/klipper_extras/buffer_feeder.py
@@ -4147,14 +4147,27 @@ class BufferFeeder:
         fast_spd = gcmd.get_float('FAST_SPD', self.unload_fast_speed, above=0.)
         max_distance = gcmd.get_float('MAX_DISTANCE', self.unload_fast_max, above=0.)
         heat_to = gcmd.get_float('AUTO_HEAT_TARGET', 250.0, above=0.)
+        temp_window = gcmd.get_float('TEMP_WINDOW', 5.0, minval=0.)
         extruder_name = gcmd.get('EXTRUDER', 'extruder')
 
         temp = self._hotend_temp()
         if temp < self.min_temp:
+            # M104 + TEMPERATURE_WAIT MINIMUM statt M109 (User-Request
+            # 2026-07-13): M109 wartet bis exakt eingeregelt (inkl.
+            # Runter-Warten bei Overshoot) — hier reicht "warm genug".
+            # Weiterlauf sobald Ziel - TEMP_WINDOW erreicht ist; Clamp
+            # auf min_temp, damit die G1-E-Moves nicht unter der
+            # Extrude-Schwelle starten. Der Heater regelt waehrenddessen
+            # weiter auf das volle Ziel.
+            wait_min = max(self.min_temp, heat_to - temp_window)
             self._gcode_run_script_checked(
-                "M118 Hotend zu kalt (%d/%d C) - heize automatisch auf %d C\n"
-                "M109 S%d"
-                % (int(temp), int(self.min_temp), int(heat_to), int(heat_to)),
+                "M118 Hotend zu kalt (%d/%d C) - heize automatisch auf %d C "
+                "(weiter ab %d C)\n"
+                "M104 S%d\n"
+                "TEMPERATURE_WAIT SENSOR=%s MINIMUM=%d"
+                % (int(temp), int(self.min_temp), int(heat_to),
+                   int(wait_min), int(heat_to), extruder_name,
+                   int(wait_min)),
                 from_command=True)
 
         state_saved = False

--- a/lll.cfg
+++ b/lll.cfg
@@ -223,6 +223,10 @@ description: Filament laden (Feeder-Push -> Buffer-Fill -> Extruder-Push)
 # heizt das Macro automatisch auf auto_heat_target (default 250 C) statt
 # abzubrechen. Anpassen je nach Material (PETG 240, ABS 245, PLA 215, ...).
 variable_auto_heat_target: 250
+# Temperaturfenster fuers Aufheizen: Macro laeuft weiter sobald
+# auto_heat_target - temp_window erreicht ist (kein exaktes M109-
+# Einregeln, kein Runter-Warten). 0 = altes Verhalten via MINIMUM=Ziel.
+variable_temp_window: 5
 gcode:
     {% set bf       = printer["buffer_feeder mellow"] %}
     {% set temp     = printer.extruder.temperature %}
@@ -249,9 +253,17 @@ gcode:
     # sonst zu niedrig heizen (oder sogar runterwarten) und der G1 E
     # scheitert trotzdem.
     {% set heat_target = [heat_to, need_temp]|max %}
+    # M104 + TEMPERATURE_WAIT MINIMUM statt M109 (2026-07-13): M109
+    # wartet bis exakt eingeregelt (inkl. Runter-Warten bei Overshoot).
+    # Hier reicht "warm genug": Weiterlauf ab heat_target - temp_window,
+    # geclampt auf need_temp (G1 E braucht min_extrude_temp). Der
+    # Heater regelt waehrenddessen weiter auf das volle Ziel.
+    {% set temp_window = printer["gcode_macro LOAD_FILAMENT"].temp_window %}
+    {% set wait_min = [heat_target - temp_window, need_temp]|max %}
     {% if temp < need_temp %}
-        M118 Hotend zu kalt ({temp|int}/{need_temp|int} C) — heize automatisch auf {heat_target|int} C
-        M109 S{heat_target}
+        M118 Hotend zu kalt ({temp|int}/{need_temp|int} C) — heize automatisch auf {heat_target|int} C (weiter ab {wait_min|int} C)
+        M104 S{heat_target}
+        TEMPERATURE_WAIT SENSOR=extruder MINIMUM={wait_min}
     {% endif %}
 
     # Warnung wenn load_fast_distance noch der Python-Default 1000mm ist —

--- a/tests/test_temp_window_heat.py
+++ b/tests/test_temp_window_heat.py
@@ -1,0 +1,64 @@
+"""Temperaturfenster fuer LOAD/UNLOAD-Aufheizen (User-Request 2026-07-13).
+
+M109 wartet auf Ziel-Temperatur in BEIDE Richtungen (inkl. Runter-
+Warten bei Ueberschwingen) und blockiert bis exakt eingeregelt.
+Fuer LOAD/UNLOAD reicht "warm genug": M104 (Ziel setzen) +
+TEMPERATURE_WAIT MINIMUM=(Ziel - Fenster, geclampt auf min_temp) —
+kein Runter-Warten, Weiterlauf sobald das Fenster erreicht ist.
+Fenster via TEMP_WINDOW-Param (Default 5.0 C).
+"""
+
+from fakes_klipper import FakeConfig, FakePrinter
+from helpers import FakeGCmd
+from klipper_extras import buffer_feeder
+
+
+def make_cold_feeder(temp=100.0):
+    printer = FakePrinter()
+    feeder = buffer_feeder.BufferFeeder(FakeConfig(printer=printer))
+    printer.fire_event('klippy:connect')
+    feeder._startup_grace_done = True
+    printer.lookup_object('extruder').heater.temperature = temp
+    return printer, feeder
+
+
+def heat_script(printer):
+    scripts = [s for _, s in printer.lookup_object('gcode').scripts]
+    return scripts[0] if scripts else ""
+
+
+def test_unload_heat_uses_temperature_wait_window():
+    printer, feeder = make_cold_feeder(temp=100.0)
+
+    feeder.cmd_BUFFER_UNLOAD_FILAMENT(FakeGCmd())
+
+    script = heat_script(printer)
+    assert "M109" not in script, (
+        "M109 waits for the exact target (both directions) — use "
+        "M104 + TEMPERATURE_WAIT MINIMUM with a window instead")
+    assert "M104 S250" in script
+    assert "TEMPERATURE_WAIT SENSOR=extruder MINIMUM=245" in script, (
+        "default window is 5C below AUTO_HEAT_TARGET=250")
+
+
+def test_unload_heat_window_param_and_min_temp_clamp():
+    printer, feeder = make_cold_feeder(temp=100.0)
+
+    feeder.cmd_BUFFER_UNLOAD_FILAMENT(
+        FakeGCmd({'AUTO_HEAT_TARGET': 182.0, 'TEMP_WINDOW': 20.0}))
+
+    script = heat_script(printer)
+    # 182-20=162 laege unter min_temp (180) -> Clamp auf min_temp,
+    # sonst laufen die G1-E-Moves unter der Extrude-Schwelle los.
+    assert "TEMPERATURE_WAIT SENSOR=extruder MINIMUM=180" in script
+
+
+def test_unload_no_heat_when_warm_enough():
+    printer, feeder = make_cold_feeder(temp=220.0)
+
+    feeder.cmd_BUFFER_UNLOAD_FILAMENT(FakeGCmd())
+
+    assert "TEMPERATURE_WAIT" not in heat_script(printer).split("\n")[0] \
+        or "MINIMUM" not in heat_script(printer)
+    assert "M104 S250" not in heat_script(printer), (
+        "temp >= min_temp: no auto-heat at all (existing behavior)")


### PR DESCRIPTION
M104 + TEMPERATURE_WAIT MINIMUM=(Ziel−Fenster) statt exaktem M109-Einregeln; Clamps auf min_temp/need_temp; UNLOAD-Param TEMP_WINDOW, LOAD-Macro variable_temp_window (Default 5). Suite: 589 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)