### PR TITLE
fix: Motor stromlos im Standby — Idle-Disable bei vollem Buffer + hold_current

### DIFF
--- a/klipper_extras/buffer_feeder.py
+++ b/klipper_extras/buffer_feeder.py
@@ -1547,7 +1547,10 @@ class BufferFeeder:
                         _blocking.append("_continuous_feed")
                     if self.hall_empty:
                         _blocking.append("hall_empty")
-                    if self.hall_full:
+                    if self.hall_full and not self.idle_motor_disable:
+                        # Bei Weg 2 blockt hall_full nicht mehr (siehe
+                        # hall_full_block unten) — nicht als Blocker
+                        # loggen.
                         _blocking.append("hall_full")
                     # separate watermark for log-rate (not
                     # _last_idle_anchor_time — that is only updated when
@@ -1668,6 +1671,21 @@ class BufferFeeder:
 
             hall_empty_block = (self.hall_empty
                                 and not self.use_flush_callback_bang_bang)
+            # hall_full blockt nur noch Weg-1-Anchors (enabled: ~18mm/h
+            # Drift Richtung HALL1, Codex-Verify) und den P7-78-Print-
+            # Override (submittet ebenfalls enabled). Bei Weg 2
+            # (idle_motor_disable) laeuft der Anchor enable-los — der
+            # Treiber ignoriert die Pulse, kein Drift — und NUR ueber
+            # diesen Anchor erreicht AUTO den Idle-Disable. Vorher
+            # blieb der Stepper nach LOAD (Buffer voll -> hall_full)
+            # dauerhaft bestromt (User-Report 2026-07-13: Motor
+            # kochend heiss im Standby). Der allererste Weg-2-Anchor
+            # kann den noch enabled Motor einmalig 0.05mm bewegen —
+            # danach ist er disabled und alle Folge-Anchors sind
+            # bewegungslos.
+            hall_full_block = (self.hall_full
+                               and (not self.idle_motor_disable
+                                    or _p778_override))
             if (self._state in (STATE_IDLE, STATE_AUTO)
                     and not self._stepper_synced_to
                     and not self._pending_disable
@@ -1675,7 +1693,7 @@ class BufferFeeder:
                     and self._pending_remaining_mm == 0.0
                     and not self._continuous_feed
                     and not hall_empty_block
-                    and not self.hall_full
+                    and not hall_full_block
                     and not _print_active):  # P7-77 A + P7-78 Override
                 # _needs_overflow_prime blockt den Watchdog NICHT mehr
                 # (Review 2026-07-09 F3): das Flag leakte in IDLE (kein

--- a/lll.cfg
+++ b/lll.cfg
@@ -164,6 +164,12 @@ min_temp: 180                     # °C — LOAD/UNLOAD Hotend-Check
 [tmc2208 buffer_feeder mellow]
 uart_pin: LLL_PLUS:PB1
 run_current: 0.450
+# Haltestrom reduziert (2026-07-13): der Buffer braucht im Stillstand
+# kaum Haltemoment — 0.2 A statt 0.45 A senkt die Motortemperatur in
+# allen enabled-Phasen ohne Bewegung deutlich. Bei Schrittverlusten
+# unter Last (sehr voller Buffer drueckt den Arm zurueck) auf 0.3 A
+# erhoehen.
+hold_current: 0.200
 # StealthChop unter 15 mm/s, SpreadCycle darueber. Zweck: der
 # Idle-Watchdog-Anchor (0.05 mm @ 10 mm/s alle ~10s, haelt
 # stepcompress.last_step_clock frisch) laeuft damit lautlos in

--- a/tests/test_auto_idle_disable_hall_full.py
+++ b/tests/test_auto_idle_disable_hall_full.py
@@ -1,0 +1,81 @@
+"""Motor bleibt nach LOAD dauerbestromt (User-Report 2026-07-13).
+
+Wurzel: Der AUTO-Idle-Disable (idle_motor_disable=True, Weg 2) laeuft
+nur NACH einem Watchdog-Anchor — das Watchdog-Gate blockt aber bei
+hall_full. Nach LOAD/park_full ist der Buffer voll -> Anchor feuert
+nie -> Disable-Zweig nie erreicht -> Stepper stundenlang bestromt
+(kochend heiss).
+
+Das hall_full-Gate stammt aus Weg 1: ein ENABLED-Anchor schiebt
+~18 mm/h Richtung HALL1 (Codex-Verify-Finding). Bei Weg 2 laeuft der
+Anchor enable-los (skip_enable, Treiber stromlos -> ignoriert Pulse)
+— der Drift-Grund entfaellt. Fix: hall_full blockt nur noch bei Weg 1
+oder im P7-78-Print-Override (dessen Anchor enabled + forced_t0
+submittet, dort bleibt der Drift-Schutz noetig).
+"""
+
+import pytest
+from fakes_klipper import FakeConfig, FakePrinter
+from klipper_extras import buffer_feeder
+
+
+def set_sensor_active(feeder, sensor_name, active):
+    polarity_flip = feeder._pin_polarity_flip[sensor_name]
+    raw = (not active) if polarity_flip else active
+    feeder._pin_stable_state[sensor_name] = raw
+    feeder._pin_raw_state[sensor_name] = raw
+
+
+def make_full_auto_feeder(values=None):
+    """AUTO nach LOAD: Buffer voll (HALL2), kein Druck, Motor an."""
+    printer = FakePrinter()
+    config = FakeConfig(printer=printer, values=values)
+    feeder = buffer_feeder.BufferFeeder(config)
+    printer.fire_event('klippy:connect')
+    feeder._startup_grace_done = True
+    feeder._state = buffer_feeder.STATE_AUTO
+    set_sensor_active(feeder, 'hall_overflow', False)
+    set_sensor_active(feeder, 'hall_full', True)
+    set_sensor_active(feeder, 'hall_empty', False)
+    set_sensor_active(feeder, 'entrance', True)
+    feeder.reactor.now = 20.0
+    feeder._last_move_end_time = 0.0
+    return printer, feeder
+
+
+def spies(monkeypatch, feeder):
+    anchors, disables = [], []
+
+    def _anchor_spy(**kw):
+        anchors.append(kw)
+        feeder._last_move_end_time = 20.001
+        return 1.0
+    monkeypatch.setattr(feeder.sync, "_submit_anchor_move", _anchor_spy)
+    monkeypatch.setattr(feeder, "_schedule_stepper_disable",
+                        lambda: disables.append('disable'))
+    return anchors, disables
+
+
+def test_weg2_anchor_and_disable_fire_despite_hall_full(monkeypatch):
+    _, feeder = make_full_auto_feeder(values={'idle_motor_disable': True})
+    anchors, disables = spies(monkeypatch, feeder)
+
+    feeder._main_tick(eventtime=20.0)
+
+    assert len(anchors) == 1, (
+        "Weg 2: enable-less anchor must fire despite hall_full — the "
+        "drift rationale only applies to enabled (Weg 1) anchors")
+    assert anchors[0].get('skip_enable') is True
+    assert disables == ['disable'], (
+        "the whole point: motor must go powerless after the anchor")
+
+
+def test_weg1_still_blocked_by_hall_full(monkeypatch):
+    _, feeder = make_full_auto_feeder(values={'idle_motor_disable': False})
+    anchors, _ = spies(monkeypatch, feeder)
+
+    feeder._main_tick(eventtime=20.0)
+
+    assert anchors == [], (
+        "Weg 1 keeps the hall_full block — enabled anchors push "
+        "~18mm/h toward HALL1 overflow")


### PR DESCRIPTION
Root-Fix: hall_full-Watchdog-Gate blockt Weg-2-Anchors (enable-los, driftfrei) nicht mehr — der AUTO-Idle-Disable greift jetzt auch nach LOAD mit vollem Buffer. Plus hold_current 0.2A im TMC2208. Suite: 591 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)